### PR TITLE
Working single-line ellipsis in CardHeader without calculations (no delay)

### DIFF
--- a/src/Components/DnDLayout/GridTile.scss
+++ b/src/Components/DnDLayout/GridTile.scss
@@ -24,4 +24,22 @@
   .pf-v5-c-card__header:first-child {
     padding-top: var(--pf-v5-global--spacer--md);
   }
+
+  // use ellipsis without calculating width
+  .pf-v5-c-card__title {
+    position: relative;
+    &:before {
+      content: '&nbsp;';
+      visibility: hidden;
+    }
+    &-text {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -24,6 +24,8 @@ import { WidgetTypes } from '../Widgets/widgetTypes';
 import widgetMapper from '../Widgets/widgetMapper';
 import { ExtendedLayoutItem } from '../../api/dashboard-templates';
 
+import { BaconIcon } from '@patternfly/react-icons';
+
 export type SetWidgetAttribute = <T extends string | number | boolean>(id: string, attributeName: keyof ExtendedLayoutItem, value: T) => void;
 
 export type GridTileProps = React.PropsWithChildren<{
@@ -136,13 +138,6 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
     </>
   );
 
-  const titleWidth = useMemo(
-    // 88px is the width of the actions container
-    // 48px is the width padding on the card title
-    // 16px is the width of the left padding on the actions handle
-    () => `calc(${widgetConfig.colWidth * widgetConfig.w}px - 48px${widgetConfig.locked ? '' : ' - 88px - 16px'})`,
-    [widgetConfig.colWidth, widgetConfig.w, widgetConfig.locked]
-  );
   return (
     <Card
       className={clsx('grid-tile', {
@@ -150,14 +145,10 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
       })}
     >
       <CardHeader actions={{ actions: headerActions }}>
-        <CardTitle
-          style={{
-            userSelect: isDragging ? 'none' : 'auto',
-            width: titleWidth,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
+        <CardTitle>
+          <Icon className="pf-v5-u-pr-sm" isInline>
+            <BaconIcon />
+          </Icon>
           {title}
         </CardTitle>
       </CardHeader>


### PR DESCRIPTION
Old

![Screenshot 2024-03-04 at 3 55 45 PM](https://github.com/RedHatInsights/widget-layout/assets/1287144/3b440910-0ee9-432e-addd-fb53e00347d9)

![Screenshot 2024-03-04 at 3 52 13 PM](https://github.com/RedHatInsights/widget-layout/assets/1287144/f2ada03e-0011-4330-acf4-229fd88129db)


New
![Screenshot 2024-03-04 at 3 46 57 PM](https://github.com/RedHatInsights/widget-layout/assets/1287144/2fdb7d16-281b-43b1-a724-c8f4b63ab2f5)
