### PR TITLE
Fix dropdown alignment

### DIFF
--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -83,7 +83,7 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
             removeWidget(widgetConfig.i);
           }}
           icon={
-            <Icon status={widgetConfig.static ? undefined : 'danger'}>
+            <Icon className="pf-v5-u-pb-2xl" status={widgetConfig.static ? undefined : 'danger'}>
               <MinusCircleIcon />
             </Icon>
           }
@@ -91,7 +91,8 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
         >
           Remove
           <HelperText>
-            <HelperTextItem variant="indeterminate">{"All 'removed' widgets can be added back by clicking the 'Add widgets' button."}</HelperTextItem>
+            <HelperTextItem variant="indeterminate">{"All 'removed' widgets can be added back"}</HelperTextItem>
+            <HelperTextItem variant="indeterminate">{"by clicking the 'Add widgets' button."}</HelperTextItem>
           </HelperText>
         </DropdownItem>
       </>
@@ -104,6 +105,7 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
         <Dropdown
           popperProps={{
             appendTo: document.body,
+            position: "right",
           }}
           toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
             <MenuToggle


### PR DESCRIPTION
- Right-align dropdown
- Break-up helper text to match mocks

Old
![Screenshot 2024-03-06 at 09 57 34](https://github.com/RedHatInsights/widget-layout/assets/1287144/958c5ece-24d1-41c5-9255-6124ce3b4877)

New
![Screenshot 2024-03-06 at 09 55 07](https://github.com/RedHatInsights/widget-layout/assets/1287144/5551a1dd-6d5d-4b7f-8106-62d433dce851)
