### PR TITLE
Ability to add link in widget header

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -5,7 +5,7 @@ import ResizeHandleIcon from './resize-handle.svg';
 import GridTile, { SetWidgetAttribute } from './GridTile';
 import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isWidgetType } from '../Widgets/widgetTypes';
-import { widgetDefaultHeight, widgetDefaultWidth, widgetMaxHeight, widgetMinHeight } from '../Widgets/widgetDefaults';
+import { widgetDefaultHeight, widgetDefaultLink, widgetDefaultWidth, widgetMaxHeight, widgetMinHeight } from '../Widgets/widgetDefaults';
 import { useAtom } from 'jotai';
 import { currentDropInItemAtom } from '../../state/currentDropInItemAtom';
 import { activeItemAtom, layoutAtom, layoutVariantAtom, prevLayoutAtom } from '../../state/layoutAtom';
@@ -342,6 +342,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
                 widgetConfig={{ ...rest, colWidth: 1200 / 4 }}
                 setWidgetAttribute={setWidgetAttribute}
                 removeWidget={removeWidget}
+                link={widgetDefaultLink[widgetType]}
               >
                 {rest.i}
               </GridTile>

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable prettier/prettier */
 import {
+  Button,
   Card,
   CardBody,
   CardHeader,
@@ -40,9 +42,10 @@ export type GridTileProps = React.PropsWithChildren<{
     locked?: boolean;
   };
   removeWidget: (id: string) => void;
+  link?: { title: string; href: string };
 }>;
 
-const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget }: GridTileProps) => {
+const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget, link }: GridTileProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const Component = widgetMapper[widgetType] || Fragment;
@@ -162,6 +165,11 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
           >
             {title}
           </CardTitle>
+          {link && (
+            <Button className="pf-v5-u-p-0" variant="link" onClick={() => window.open(link.href, '_blank')}>
+              {link.title}
+            </Button>
+          )}
         </Flex>
       </CardHeader>
       <Divider />

--- a/src/Components/Widgets/widgetDefaults.ts
+++ b/src/Components/Widgets/widgetDefaults.ts
@@ -24,3 +24,9 @@ export const widgetMinHeight: { [widgetName in WidgetTypes]: number } = {
   [WidgetTypes.MediumWidget]: 1,
   [WidgetTypes.SmallWidget]: 1,
 };
+
+export const widgetDefaultLink: { [widgetName in WidgetTypes]: { title: string; href: string } | undefined } = {
+  [WidgetTypes.LargeWidget]: { title: 'Learn more', href: '#' },
+  [WidgetTypes.MediumWidget]: undefined,
+  [WidgetTypes.SmallWidget]: undefined,
+};


### PR DESCRIPTION
[RHCLOUD-31497](https://issues.redhat.com/browse/RHCLOUD-31497)
- Adds ability to add link in widget header
- Link can be defined in `widgetDefaults.ts` and requires a `title` and `href`
- Links open in new tab

![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/ff429e4e-7a16-419e-a2b5-06d8d2d9beee)
