### PR TITLE
Add ability to set link in widget header

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -5,7 +5,7 @@ import ResizeHandleIcon from './resize-handle.svg';
 import GridTile, { SetWidgetAttribute } from './GridTile';
 import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isWidgetType } from '../Widgets/widgetTypes';
-import { widgetDefaultHeight, widgetDefaultWidth, widgetMaxHeight, widgetMinHeight } from '../Widgets/widgetDefaults';
+import { widgetDefaultHeight, widgetDefaultWidth, widgetHeaderLink, widgetMaxHeight, widgetMinHeight } from '../Widgets/widgetDefaults';
 import { useAtom, useAtomValue } from 'jotai';
 import { currentDropInItemAtom } from '../../state/currentDropInItemAtom';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
@@ -347,6 +347,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
                 widgetConfig={{ ...rest, colWidth: 1200 / 4 }}
                 setWidgetAttribute={setWidgetAttribute}
                 removeWidget={removeWidget}
+                link={widgetHeaderLink[widgetType]}
               >
                 {rest.i}
               </GridTile>

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -26,6 +26,7 @@ import useCurrentUser from '../../hooks/useCurrentUser';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { debounce, isEqual } from 'lodash';
+import { getWidget } from '../Widgets/widgetDefaults';
 
 export const dropping_elem_id = '__dropping-elem__';
 
@@ -63,6 +64,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
         i: dropping_elem_id,
         widgetType: currentDropInItem,
         title: 'New title',
+        config: widgetMapping[currentDropInItem].config,
       };
     }
   }, [currentDropInItem]);
@@ -88,6 +90,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
         widgetType: data,
         i: getWidgetIdentifier(data),
         title: 'New title',
+        config: widgetMapping[data].config,
       };
       setCurrentDropInItem(undefined);
       setLayout((prev) =>
@@ -323,32 +326,34 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
       >
         {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          activeLayout.map(({ widgetType, title, ...rest }, index) => (
-            <div
-              key={rest.i}
-              data-grid={rest}
-              onKeyUp={(e) => onKeyUp(e, rest.i)}
-              tabIndex={index}
-              style={{
-                boxShadow: activeItem === rest.i ? '0 0 2px 2px #2684FF' : 'none',
-                ...(activeItem === rest.i ? { outline: 'none' } : {}),
-              }}
-            >
-              <GridTile
-                isDragging={isDragging}
-                setIsDragging={setIsDragging}
-                title={rest.i}
-                widgetType={widgetType}
-                // these will be dynamically calculated once the dimensions are calculated
-                widgetConfig={{ ...rest, colWidth: 1200 / 4 }}
-                setWidgetAttribute={setWidgetAttribute}
-                removeWidget={removeWidget}
-                link={widgetHeaderLink[widgetType]}
+          activeLayout.map(({ widgetType, title, ...rest }, index) => {
+            const { config } = getWidget(widgetMapping, widgetType);
+            return (
+              <div
+                key={rest.i}
+                data-grid={rest}
+                onKeyUp={(e) => onKeyUp(e, rest.i)}
+                tabIndex={index}
+                style={{
+                  boxShadow: activeItem === rest.i ? '0 0 2px 2px #2684FF' : 'none',
+                  ...(activeItem === rest.i ? { outline: 'none' } : {}),
+                }}
               >
-                {rest.i}
-              </GridTile>
-            </div>
-          ))
+                <GridTile
+                  isDragging={isDragging}
+                  setIsDragging={setIsDragging}
+                  title={rest.i}
+                  widgetType={widgetType}
+                  // these will be dynamically calculated once the dimensions are calculated
+                  widgetConfig={{ ...rest, colWidth: 1200 / 4, config }}
+                  setWidgetAttribute={setWidgetAttribute}
+                  removeWidget={removeWidget}
+                >
+                  {rest.i}
+                </GridTile>
+              </div>
+            );
+          })
         }
       </ResponsiveGridLayout>
     </div>

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -49,6 +49,7 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
   const [isOpen, setIsOpen] = useState(false);
   const widgetMapping = useAtomValue(widgetMappingAtom);
   const { headerLink } = widgetConfig.config || {};
+  const hasHeader = headerLink && headerLink.href && headerLink.title;
 
   const { node, module, scope } = useMemo(() => {
     return getWidget(widgetMapping, widgetType);
@@ -170,7 +171,7 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
           >
             {title}
           </CardTitle>
-          {headerLink && (
+          {hasHeader && (
             <Button className="widget-header-link pf-v5-u-p-0" variant="link" onClick={() => window.open(headerLink.href, '_blank')}>
               {headerLink.title}
             </Button>

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Card,
   CardBody,
   CardHeader,
@@ -40,9 +41,10 @@ export type GridTileProps = React.PropsWithChildren<{
     locked?: boolean;
   };
   removeWidget: (id: string) => void;
+  link?: { title: string; href: string };
 }>;
 
-const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget }: GridTileProps) => {
+const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget, link }: GridTileProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const widgetMapping = useAtomValue(widgetMappingAtom);
 
@@ -161,6 +163,11 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
           >
             {title}
           </CardTitle>
+          {link && (
+            <Button className="pf-v5-u-p-0" variant="link" onClick={() => window.open(link.href, '_blank')}>
+              {link.title}
+            </Button>
+          )}
         </Flex>
       </CardHeader>
       <Divider />

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -22,7 +22,7 @@ import clsx from 'clsx';
 
 import './GridTile.scss';
 import { Layout } from 'react-grid-layout';
-import { ExtendedLayoutItem } from '../../api/dashboard-templates';
+import { ExtendedLayoutItem, WidgetConfiguration } from '../../api/dashboard-templates';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
 import { BaconIcon } from '@patternfly/react-icons';
 import { getWidget } from '../Widgets/widgetDefaults';
@@ -40,14 +40,15 @@ export type GridTileProps = React.PropsWithChildren<{
   widgetConfig: Layout & {
     colWidth: number;
     locked?: boolean;
+    config?: WidgetConfiguration;
   };
   removeWidget: (id: string) => void;
-  link?: { title: string; href: string };
 }>;
 
-const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget, link }: GridTileProps) => {
+const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget }: GridTileProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const widgetMapping = useAtomValue(widgetMappingAtom);
+  const { headerLink } = widgetConfig.config || {};
 
   const { node, module, scope } = useMemo(() => {
     return getWidget(widgetMapping, widgetType);
@@ -169,9 +170,9 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
           >
             {title}
           </CardTitle>
-          {link && (
-            <Button className="pf-v5-u-p-0" variant="link" onClick={() => window.open(link.href, '_blank')}>
-              {link.title}
+          {headerLink && (
+            <Button className="widget-header-link pf-v5-u-p-0" variant="link" onClick={() => window.open(headerLink.href, '_blank')}>
+              {headerLink.title}
             </Button>
           )}
         </Flex>

--- a/src/Components/Widgets/widgetDefaults.tsx
+++ b/src/Components/Widgets/widgetDefaults.tsx
@@ -9,5 +9,6 @@ export const getWidget = (widgetMapping: WidgetMapping, type: string) => {
     scope: mappedWidget?.scope,
     module: mappedWidget?.module,
     importName: mappedWidget?.importName,
+    config: mappedWidget?.config,
   };
 };

--- a/src/Components/Widgets/widgetDefaults.tsx
+++ b/src/Components/Widgets/widgetDefaults.tsx
@@ -23,6 +23,11 @@ export const widgetMinHeight: { [widgetName: string]: number } = {
   ['notificationsEvents']: 1,
 };
 
+export const widgetHeaderLink: { [widgetName: string]: { title: string; href: string } | undefined } = {
+  ['favoriteServices']: { title: 'View all services', href: '/allservices' },
+  ['notificationsEvents']: undefined,
+};
+
 export const getWidget = (widgetMapping: WidgetMapping, type: string) => {
   const mappedWidget = widgetMapping[type];
   return mappedWidget ? <ScalprumComponent {...mappedWidget} /> : Fragment;

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -25,6 +25,7 @@ export type PartialTemplateConfig = Partial<TemplateConfig>;
 // extended type the UI tracks but not the backend
 export type ExtendedLayoutItem = LayoutWithTitle & {
   widgetType: string;
+  config?: WidgetConfiguration;
   locked?: boolean;
 };
 
@@ -81,9 +82,20 @@ export type WidgetDefaults = {
   minH: number;
 };
 
+export type WidgetHeaderLink = {
+  title?: string;
+  href?: string;
+};
+
+export type WidgetConfiguration = {
+  icon?: string;
+  headerLink?: WidgetHeaderLink;
+};
+
 export type WidgetMapping = {
   [key: string]: Pick<ScalprumComponentProps, 'scope' | 'module' | 'importName'> & {
     defaults: WidgetDefaults;
+    config?: WidgetConfiguration;
   };
 };
 


### PR DESCRIPTION
[RHCLOUD-31497](https://issues.redhat.com/browse/RHCLOUD-31497)
- Adds ability to add link in widget header
- Link can be defined in `widgetDefaults.tsx` and requires a `title` and `href`
- Links open in new tab

(See 'View all services' below)
![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/304acf8d-3c0e-43d5-9b90-2e2d7551e03e)
