### PR TITLE
Consume widget defaults from API.

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -5,7 +5,6 @@ import ResizeHandleIcon from './resize-handle.svg';
 import GridTile, { SetWidgetAttribute } from './GridTile';
 import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isWidgetType } from '../Widgets/widgetTypes';
-import { widgetDefaultHeight, widgetDefaultWidth, widgetMaxHeight, widgetMinHeight } from '../Widgets/widgetDefaults';
 import { useAtom, useAtomValue } from 'jotai';
 import { currentDropInItemAtom } from '../../state/currentDropInItemAtom';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
@@ -58,11 +57,10 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
 
   const [currentDropInItem, setCurrentDropInItem] = useAtom(currentDropInItemAtom);
   const droppingItemTemplate: ReactGridLayoutProps['droppingItem'] = useMemo(() => {
-    if (currentDropInItem) {
+    if (currentDropInItem && isWidgetType(widgetMapping, currentDropInItem)) {
       return {
+        ...widgetMapping[currentDropInItem].defaults,
         i: dropping_elem_id,
-        w: widgetDefaultWidth[currentDropInItem],
-        h: widgetDefaultHeight[currentDropInItem],
         widgetType: currentDropInItem,
         title: 'New title',
       };
@@ -83,12 +81,10 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
     if (isWidgetType(widgetMapping, data)) {
       const newWidget = {
         ...layoutItem,
+        ...widgetMapping[data].defaults,
         // w: layoutItem.x + layoutItem.w > 3 ? 1 : 3,
         // x: 4 % layoutItem.w,
         // x: layoutItem.x + layoutItem.w > 3 ? 3 : 0,
-        h: widgetDefaultHeight[data],
-        maxH: widgetMaxHeight[data],
-        minH: widgetMinHeight[data],
         widgetType: data,
         i: getWidgetIdentifier(data),
         title: 'New title',

--- a/src/Components/Widgets/widgetDefaults.tsx
+++ b/src/Components/Widgets/widgetDefaults.tsx
@@ -2,27 +2,6 @@ import { ScalprumComponent } from '@scalprum/react-core';
 import { WidgetMapping } from '../../api/dashboard-templates';
 import React, { Fragment } from 'react';
 
-// TODO these will depend entirely on widget implementation
-export const widgetDefaultWidth: { [widgetName: string]: number } = {
-  ['favoriteServices']: 4,
-  ['notificationsEvents']: 2,
-};
-
-export const widgetDefaultHeight: { [widgetName: string]: number } = {
-  ['favoriteServices']: 3,
-  ['notificationsEvents']: 2,
-};
-
-export const widgetMaxHeight: { [widgetName: string]: number } = {
-  ['favoriteServices']: 6,
-  ['notificationsEvents']: 4,
-};
-
-export const widgetMinHeight: { [widgetName: string]: number } = {
-  ['favoriteServices']: 1,
-  ['notificationsEvents']: 1,
-};
-
 export const getWidget = (widgetMapping: WidgetMapping, type: string) => {
   const mappedWidget = widgetMapping[type];
   return mappedWidget ? <ScalprumComponent {...mappedWidget} /> : Fragment;

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -74,8 +74,17 @@ export class DashboardTemplatesError extends Error {
   }
 }
 
+export type WidgetDefaults = {
+  w: number;
+  h: number;
+  maxH: number;
+  minH: number;
+};
+
 export type WidgetMapping = {
-  [key: string]: Pick<ScalprumComponentProps, 'scope' | 'module' | 'importName'>;
+  [key: string]: Pick<ScalprumComponentProps, 'scope' | 'module' | 'importName'> & {
+    defaults: WidgetDefaults;
+  };
 };
 
 const handleErrors = (resp: Response) => {


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-31551

Requires: https://github.com/RedHatInsights/chrome-service-backend/pull/443
