### PR TITLE
Add classnames to grid card body based on module federation metadata.

### DIFF
--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -26,6 +26,7 @@ import { widgetMappingAtom } from '../../state/widgetMappingAtom';
 import { BaconIcon } from '@patternfly/react-icons';
 import { getWidget } from '../Widgets/widgetDefaults';
 import { useAtomValue } from 'jotai';
+import classNames from 'classnames';
 
 export type SetWidgetAttribute = <T extends string | number | boolean>(id: string, attributeName: keyof ExtendedLayoutItem, value: T) => void;
 
@@ -45,6 +46,10 @@ export type GridTileProps = React.PropsWithChildren<{
 const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget }: GridTileProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const widgetMapping = useAtomValue(widgetMappingAtom);
+
+  const { node, module, scope } = useMemo(() => {
+    return getWidget(widgetMapping, widgetType);
+  }, [widgetMapping, widgetType]);
 
   const dropdownItems = useMemo(() => {
     const isMaximized = widgetConfig.h === widgetConfig.maxH;
@@ -146,6 +151,7 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
     <Card
       className={clsx('grid-tile', {
         static: widgetConfig.static,
+        [scope]: scope && module,
       })}
     >
       <CardHeader actions={{ actions: headerActions }}>
@@ -164,7 +170,13 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
         </Flex>
       </CardHeader>
       <Divider />
-      <CardBody className="pf-v5-u-p-0">{getWidget(widgetMapping, widgetType)}</CardBody>
+      <CardBody
+        className={classNames('pf-v5-u-p-0', {
+          [`${scope}-${module}`]: scope && module,
+        })}
+      >
+        {node}
+      </CardBody>
     </Card>
   );
 };

--- a/src/Components/Widgets/widgetDefaults.tsx
+++ b/src/Components/Widgets/widgetDefaults.tsx
@@ -4,5 +4,10 @@ import React, { Fragment } from 'react';
 
 export const getWidget = (widgetMapping: WidgetMapping, type: string) => {
   const mappedWidget = widgetMapping[type];
-  return mappedWidget ? <ScalprumComponent {...mappedWidget} /> : Fragment;
+  return {
+    node: mappedWidget ? <ScalprumComponent {...mappedWidget} /> : <Fragment />,
+    scope: mappedWidget?.scope,
+    module: mappedWidget?.module,
+    importName: mappedWidget?.importName,
+  };
 };


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-31649

Each card body now has a new CSS class equal to `<scope>-<module>` based on the module federation metadata.

Sample CSS from the landing page

```scss
.landing-\.\/RhelWidget {
  background: red !important;
  width: 60px;
  .pf-v5-c-card__body {
    background: red !important;
  }
}
```

Note that because the exposed module uses special characters `.` and `/` in its identifier, they need to be escaped while defining selectors.

Result:

![Screenshot from 2024-03-27 09-24-58](https://github.com/RedHatInsights/widget-layout/assets/22619452/c8f8bf99-3c33-4545-8e7a-08b5f5297dff)



