### PR TITLE
Create empty state for widget layout

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4,7 +4,8 @@
 .widg-l-flex--header,
 .widg-l-split--add-widget,
 .widg-l-gallery,
-.layout
+.layout,
+.empty-layout
 {
   max-width: 1280px;
 }

--- a/src/Components/DnDLayout/GridLayout.scss
+++ b/src/Components/DnDLayout/GridLayout.scss
@@ -33,3 +33,11 @@
     }
   }
 }
+
+.layout {
+  min-height: 1rem;
+}
+
+.empty-layout {
+  border-bottom: none;
+}

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -26,6 +26,8 @@ import useCurrentUser from '../../hooks/useCurrentUser';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { debounce, isEqual } from 'lodash';
+import { Button, Flex, Icon, PageSection, Text, TextContent } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, GripVerticalIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 export const dropping_elem_id = '__dropping-elem__';
 
@@ -38,6 +40,28 @@ const getResizeHandle = (resizeHandleAxis: string, ref: React.Ref<HTMLDivElement
     <div ref={ref} className={`react-resizable-handle react-resizable-handle-${resizeHandleAxis}`}>
       <img src={ResizeHandleIcon} />
     </div>
+  );
+};
+
+const LayoutEmptyState = () => {
+  return (
+    <PageSection className="pf-v5-u-p-lg pf-v5-u-p-r-0-on-sm ">
+      <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+        <TextContent className="pf-v5-u-text-align-center">
+          <Icon iconSize="xl">
+            <PlusCircleIcon />
+          </Icon>
+          <Text component="h2">No dashboard content</Text>
+          <Text>
+            You don’t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to
+            this dashboard body here.
+          </Text>
+          <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end">
+            Learn about your widget dashboard
+          </Button>
+        </TextContent>
+      </Flex>
+    </PageSection>
   );
 };
 
@@ -350,6 +374,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
           ))
         }
       </ResponsiveGridLayout>
+      {activeLayout.length === 0 && <LayoutEmptyState />}
     </div>
   );
 };

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -59,8 +59,8 @@ const LayoutEmptyState = () => {
       <EmptyState variant={EmptyStateVariant.lg} className="pf-v5-u-p-sm">
         <EmptyStateHeader titleText="No dashboard content" headingLevel="h2" icon={<EmptyStateIcon icon={PlusCircleIcon} />} />
         <EmptyStateBody>
-          You don’t have any widgets on your dashboard. To populate <br /> your dashboard, drag <GripVerticalIcon /> items from the blue widget bank
-          to <br /> this dashboard body here.
+          You don’t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to this
+          dashboard body here.
         </EmptyStateBody>
         <EmptyStateActions>
           {/* TODO: Add link to documentation */}

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -58,10 +58,11 @@ const LayoutEmptyState = () => {
       <EmptyState variant={EmptyStateVariant.lg} className="pf-v5-u-p-sm">
         <EmptyStateHeader titleText="No dashboard content" headingLevel="h2" icon={<EmptyStateIcon icon={PlusCircleIcon} />} />
         <EmptyStateBody>
-          You don’t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to
-          dashboard body here.
+          You don’t have any widgets on your dashboard. To populate <br /> your dashboard, drag <GripVerticalIcon /> items from the blue widget bank
+          to <br /> this dashboard body here.
         </EmptyStateBody>
         <EmptyStateActions>
+          {/* TODO: Add link to documentation */}
           <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end">
             Learn about your widget dashboard
           </Button>

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -62,12 +62,12 @@ const LayoutEmptyState = () => {
           You don’t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to this
           dashboard body here.
         </EmptyStateBody>
+        {/* TODO: Add link to documentation once available [HCCDOC-2108]
         <EmptyStateActions>
-          {/* TODO: Add link to documentation */}
-          <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end">
+          <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end" component="a" href={`#`}>
             Learn about your widget dashboard
           </Button>
-        </EmptyStateActions>
+        </EmptyStateActions> */}
       </EmptyState>
     </PageSection>
   );

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -332,7 +332,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
     // {/* relative position is required for the grid layout to properly calculate
     // child translation while dragging is in progress */}
     <div style={{ position: 'relative' }} ref={layoutRef}>
-      {activeLayout.length === 0 && <LayoutEmptyState />}
+      {activeLayout.length === 0 && !currentDropInItem && <LayoutEmptyState />}
       <ResponsiveGridLayout
         className="layout"
         draggableHandle=".drag-handle"

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -328,6 +328,7 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
     // {/* relative position is required for the grid layout to properly calculate
     // child translation while dragging is in progress */}
     <div style={{ position: 'relative' }} ref={layoutRef}>
+      {activeLayout.length === 0 && <LayoutEmptyState />}
       <ResponsiveGridLayout
         className="layout"
         draggableHandle=".drag-handle"
@@ -380,7 +381,6 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
           ))
         }
       </ResponsiveGridLayout>
-      {activeLayout.length === 0 && <LayoutEmptyState />}
     </div>
   );
 };

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -26,7 +26,16 @@ import useCurrentUser from '../../hooks/useCurrentUser';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { debounce, isEqual } from 'lodash';
-import { Button, Flex, Icon, PageSection, Text, TextContent } from '@patternfly/react-core';
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+} from '@patternfly/react-core';
 import { ExternalLinkAltIcon, GripVerticalIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 export const dropping_elem_id = '__dropping-elem__';
@@ -45,22 +54,19 @@ const getResizeHandle = (resizeHandleAxis: string, ref: React.Ref<HTMLDivElement
 
 const LayoutEmptyState = () => {
   return (
-    <PageSection className="pf-v5-u-p-lg pf-v5-u-p-r-0-on-sm ">
-      <Flex justifyContent={{ default: 'justifyContentCenter' }}>
-        <TextContent className="pf-v5-u-text-align-center">
-          <Icon iconSize="xl">
-            <PlusCircleIcon />
-          </Icon>
-          <Text component="h2">No dashboard content</Text>
-          <Text>
-            You don’t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to
-            this dashboard body here.
-          </Text>
+    <PageSection className="empty-layout pf-v5-u-p-0">
+      <EmptyState variant={EmptyStateVariant.lg} className="pf-v5-u-p-sm">
+        <EmptyStateHeader titleText="No dashboard content" headingLevel="h2" icon={<EmptyStateIcon icon={PlusCircleIcon} />} />
+        <EmptyStateBody>
+          You don’t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to
+          dashboard body here.
+        </EmptyStateBody>
+        <EmptyStateActions>
           <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end">
             Learn about your widget dashboard
           </Button>
-        </TextContent>
-      </Flex>
+        </EmptyStateActions>
+      </EmptyState>
     </PageSection>
   );
 };


### PR DESCRIPTION
[RHCLOUD-31662](https://issues.redhat.com/browse/RHCLOUD-31662)
- Display an empty state component when all widgets are removed from the dashboard.
- Link commented out until the documentation to redirect to is created ([RHCLOUD-31806](https://issues.redhat.com/browse/RHCLOUD-31806))

![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/0d2d2119-9c96-4cf3-8193-ba91dd4ccd54)
