### PR TITLE
Pull widget titles from backend config

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -377,7 +377,6 @@ const GridLayout = ({ isLayoutLocked = false }: { isLayoutLocked?: boolean }) =>
                 <GridTile
                   isDragging={isDragging}
                   setIsDragging={setIsDragging}
-                  title={rest.i}
                   widgetType={widgetType}
                   // these will be dynamically calculated once the dimensions are calculated
                   widgetConfig={{ ...rest, colWidth: 1200 / 4, config }}

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -33,7 +33,6 @@ export type SetWidgetAttribute = <T extends string | number | boolean>(id: strin
 
 export type GridTileProps = React.PropsWithChildren<{
   widgetType: string;
-  title: string;
   icon?: React.ComponentClass;
   setIsDragging: (isDragging: boolean) => void;
   isDragging: boolean;
@@ -46,7 +45,7 @@ export type GridTileProps = React.PropsWithChildren<{
   removeWidget: (id: string) => void;
 }>;
 
-const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget }: GridTileProps) => {
+const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, widgetConfig, removeWidget }: GridTileProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const widgetMapping = useAtomValue(widgetMappingAtom);
   const { headerLink } = widgetConfig.config || {};
@@ -170,7 +169,7 @@ const GridTile = ({ widgetType, title, isDragging, setIsDragging, setWidgetAttri
             }}
             className="pf-v5-u-flex-wrap pf-v5-u-text-break-word"
           >
-            {title}
+            {widgetConfig?.config?.title || widgetType}
           </CardTitle>
           {hasHeader && (
             <Button className="widget-header-link pf-v5-u-p-0" variant="link" onClick={() => window.open(headerLink.href, '_blank')}>

--- a/src/Components/WidgetDrawer/WidgetDrawer.tsx
+++ b/src/Components/WidgetDrawer/WidgetDrawer.tsx
@@ -27,11 +27,7 @@ export type AddWidgetDrawerProps = React.PropsWithChildren<{
   dismissible?: boolean;
 }>;
 
-const WidgetWrapper = ({
-  title,
-  widgetType,
-  config,
-}: React.PropsWithChildren<{ title: string; widgetType: string; config?: WidgetConfiguration }>) => {
+const WidgetWrapper = ({ widgetType, config }: React.PropsWithChildren<{ widgetType: string; config?: WidgetConfiguration }>) => {
   const setDropInItem = useSetAtom(currentDropInItemAtom);
   const headerActions = (
     <Tooltip content={<p>Move widget</p>}>
@@ -66,7 +62,7 @@ const WidgetWrapper = ({
           <Icon status="custom" className="pf-v5-u-mr-sm">
             <HeaderIcon icon={config?.icon} />
           </Icon>
-          <CardTitle>{title}</CardTitle>
+          <CardTitle>{config?.title || widgetType}</CardTitle>
         </Flex>
       </CardHeader>
     </Card>
@@ -106,7 +102,7 @@ const AddWidgetDrawer = ({ children }: AddWidgetDrawerProps) => {
         {Object.entries(widgetMapping).map(([type, { config }], i) => {
           return (
             <GalleryItem key={i}>
-              <WidgetWrapper widgetType={type} title={type} config={config}>
+              <WidgetWrapper widgetType={type} config={config}>
                 {getWidget(widgetMapping, type)}
               </WidgetWrapper>
             </GalleryItem>

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -90,6 +90,7 @@ export type WidgetHeaderLink = {
 export type WidgetConfiguration = {
   icon?: string;
   headerLink?: WidgetHeaderLink;
+  title?: string;
 };
 
 export type WidgetMapping = {


### PR DESCRIPTION
[RHCLOUD-31816](https://issues.redhat.com/browse/RHCLOUD-31816)
- Pull the titles of the widgets from the backend config
- Fallback to the `widgetType` where title is not defined (as was previously used below in the widget drawer).

## Before
![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/b1789a10-07c5-45e0-8751-bb592cf7d388)

## After
![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/b7fbcb4f-6f7b-44c3-b0a6-d75353878730)
