### PR TITLE
Fix breakpoing layout overrides.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@redhat-cloud-services/frontend-components": "^4.2.3",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
+        "awesome-debounce-promise": "^2.1.0",
         "classnames": "^2.3.1",
         "jotai": "^2.6.4",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@redhat-cloud-services/frontend-components": "^4.2.3",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
+    "awesome-debounce-promise": "^2.1.0",
     "classnames": "^2.3.1",
     "jotai": "^2.6.4",
     "react": "^18.2.0",

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -34,7 +34,7 @@ import { CheckIcon, ExclamationCircleIcon, PlusCircleIcon, TimesIcon } from '@pa
 import React from 'react';
 import { useAtom, useSetAtom } from 'jotai';
 import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
-import { initialLayout, isDefaultLayout, layoutAtom, prevLayoutAtom } from '../../state/layoutAtom';
+import { initialLayout, isDefaultLayout, layoutAtom } from '../../state/layoutAtom';
 import useCurrentUser from '../../hooks/useCurrentUser';
 
 const Controls = () => {
@@ -42,7 +42,6 @@ const Controls = () => {
   const [customValue, setCustomValue] = React.useState('');
   const [customValueValidationError, setCustomValueValidationError] = React.useState('');
   const toggleOpen = useSetAtom(drawerExpandedAtom);
-  const setPrevLayout = useSetAtom(prevLayoutAtom);
   const [layout, setLayout] = useAtom(layoutAtom);
   const CONSOLE_DEFAULT = 'console-default';
   const CUSTOM = 'custom';
@@ -188,7 +187,6 @@ const Controls = () => {
         <Button
           onClick={() => {
             toggleOpen((prev) => !prev);
-            setPrevLayout(layout);
           }}
           variant="secondary"
           icon={<PlusCircleIcon />}

--- a/src/state/layoutAtom.ts
+++ b/src/state/layoutAtom.ts
@@ -12,6 +12,4 @@ export const layoutVariantAtom = atom<Variants>('xl');
 
 export const layoutAtom = atom<ExtendedLayoutItem[]>(initialLayout);
 
-export const prevLayoutAtom = atom<ExtendedLayoutItem[]>(initialLayout);
-
 export const activeItemAtom = atom<string | undefined>(undefined);


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-31954

### Issues
- previously debounce was recreated on each callback trigger, meaning that the requests were not debounced at all
- can't use lodash debounce as it returns undefined in some cases and all promises are resolved if triggered
- not working debounce caused the wrong config was assigned to a different layout variant (sm variant could override xl)
- when a new breakpoint was set, the related variant was not picked from the template config

### Changes
- use `awesome-debounce-promise` to debounce async actions
- lift denounced function definition out of the component lifecycle (prevents debounce re-creation)
- remove `prevLayout` as it was blocking API calls incorrectly
- set new layout on breakpoint change