### PR TITLE
Add reset layout functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
+        "@patternfly/react-component-groups": "^5.2.0-prerelease.1",
         "@patternfly/react-core": "^5.0.0",
         "@patternfly/react-table": "^5.0.0",
         "@redhat-cloud-services/frontend-components": "^4.2.3",
@@ -3254,9 +3255,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@patternfly/react-component-groups": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.0.0.tgz",
-      "integrity": "sha512-ON4h4SKOCgLRgZLd/FOj44wU19ytvFPjflxPSYU0KfCWlVgb6F62+l316/Va/tzDo/AwZypnUxOEksXDv+C2+A==",
+      "version": "5.2.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.2.0-prerelease.1.tgz",
+      "integrity": "sha512-QZ9ZEIjMcU3Vlc/UXcuIDSc61P0pLh6ZOZzCbh+jldczGhflM/ymSbC7uWEFkRCDqm2RGYf8rD9rQ6LFUPhJXQ==",
       "dependencies": {
         "@patternfly/react-core": "^5.1.1",
         "@patternfly/react-icons": "^5.1.1",
@@ -3682,6 +3683,22 @@
         "react-dom": "^18.2.0",
         "react-redux": ">=7.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@patternfly/react-component-groups": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.1.0.tgz",
+      "integrity": "sha512-DCEKc7Iyuf/7prI2a6mWyM/qwgBBtEzxDnNSpkZyes+Q3os0F5lUxW5qZVrg3JcNp0/J1183vwLdp1VoJRmcJw==",
+      "dependencies": {
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-table": "^5.1.1",
+        "clsx": "^2.0.0",
+        "react-jss": "^10.10.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@patternfly/react-core": "^5.0.0",
     "@patternfly/react-table": "^5.0.0",
+    "@patternfly/react-component-groups": "^5.2.0-prerelease.1",
     "@redhat-cloud-services/frontend-components": "^4.2.3",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -284,11 +284,11 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
     // TODO template type should be pulled from app config for reusability
     getDashboardTemplates(currentToken, layoutType)
       .then((templates) => {
-        const defaultTemplate = getDefaultTemplate(templates);
-        if (!defaultTemplate) {
-          throw new Error('No default template found');
+        const customDefaultTemplate = getDefaultTemplate(templates);
+        if (!customDefaultTemplate) {
+          throw new Error('No custom default template found');
         }
-        const extendedTemplateConfig = mapTemplateConfigToExtendedTemplateConfig(defaultTemplate.templateConfig);
+        const extendedTemplateConfig = mapTemplateConfigToExtendedTemplateConfig(customDefaultTemplate.templateConfig);
         const currentWidth = layoutRef?.current?.clientWidth || document.body.clientWidth;
         let targetVariant: Variants;
         if (currentWidth > breakpoints.lg) {
@@ -301,7 +301,7 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
           targetVariant = 'sm';
         }
         setTemplate(extendedTemplateConfig);
-        setTemplateId(defaultTemplate.id);
+        setTemplateId(customDefaultTemplate.id);
         setLayout(extendedTemplateConfig[targetVariant]);
         setLayoutVariant(targetVariant);
       })

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -2,199 +2,76 @@ import './Header.scss';
 
 import {
   Button,
-  ButtonType,
-  ClipboardCopy,
-  Dropdown,
-  DropdownGroup,
-  DropdownItem,
-  DropdownList,
+  ButtonVariant,
   Flex,
   FlexItem,
-  Form,
-  FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-  MenuToggle,
-  MenuToggleElement,
   PageSection,
   PageSectionVariants,
-  Radio,
-  Stack,
-  StackItem,
   Text,
-  TextArea,
   TextContent,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { CheckIcon, ExclamationCircleIcon, PlusCircleIcon, TimesIcon } from '@patternfly/react-icons';
 import React from 'react';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useAtom, useSetAtom } from 'jotai';
 import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
-import { initialLayout, isDefaultLayout, layoutAtom } from '../../state/layoutAtom';
+import { templateIdAtom } from '../../state/templateAtom';
+import { resetDashboardTemplate } from '../../api/dashboard-templates';
 import useCurrentUser from '../../hooks/useCurrentUser';
+import { WarningModal } from '@patternfly/react-component-groups';
 
 const Controls = () => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [customValue, setCustomValue] = React.useState('');
-  const [customValueValidationError, setCustomValueValidationError] = React.useState('');
   const toggleOpen = useSetAtom(drawerExpandedAtom);
-  const [layout, setLayout] = useAtom(layoutAtom);
-  const CONSOLE_DEFAULT = 'console-default';
-  const CUSTOM = 'custom';
-  const [checked, setChecked] = React.useState(isDefaultLayout(layout) ? CONSOLE_DEFAULT : CUSTOM);
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onCustomConfigSubmit = (e: { preventDefault: () => void }) => {
-    e.preventDefault();
-    if (!customValue) {
-      setCustomValueValidationError('Input value is required.');
-      return;
-    }
-    try {
-      const layout = JSON.parse(customValue);
-      if (isDefaultLayout(layout)) {
-        setChecked(CONSOLE_DEFAULT);
-      }
-      setLayout(layout);
-      setIsOpen(false);
-      setCustomValue('');
-    } catch (e) {
-      console.error(e);
-      setCustomValueValidationError('Invalid input value.');
-      return;
-    }
-  };
-
-  const onDefaultConfigSubmit = (e: { preventDefault: () => void }) => {
-    e.preventDefault();
-    setChecked(CONSOLE_DEFAULT);
-    setLayout(initialLayout);
-    setIsOpen(false);
-    setCustomValue('');
-  };
+  const [, setTemplateId] = useAtom(templateIdAtom);
+  const { currentToken } = useCurrentUser();
 
   return (
-    <ToolbarGroup className="pf-v5-u-flex-direction-column-reverse pf-v5-u-flex-direction-row-reverse-on-md pf-v5-u-flex-direction-row-on-lg">
-      <Flex className=" pf-v5-u-flex-nowrap pf-v5-u-flex-direction-row-reverse pf-v5-u-flex-direction-row-on-lg">
-        <ToolbarItem spacer={{ default: 'spacerNone' }}>
-          <ClipboardCopy isCode hoverTip="Copy current configuration string" position="left" clickTip="Configuration string copied to clipboard">
-            {JSON.stringify(layout)}
-          </ClipboardCopy>
+    <>
+      <WarningModal
+        withCheckbox
+        isOpen={isOpen}
+        title="Reset layout?"
+        checkboxLabel="I understand that this action cannot be undone"
+        confirmButtonLabel="Reset layout"
+        confirmButtonVariant={ButtonVariant.danger}
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => {
+          setIsOpen(false);
+          resetDashboardTemplate('landingPage', currentToken).then(() => {
+            setTemplateId(NaN);
+          });
+        }}
+      >
+        All your widget customizations will be discarded.
+      </WarningModal>
+      <ToolbarGroup className="pf-v5-u-flex-direction-column-reverse pf-v5-u-flex-direction-row-reverse-on-md pf-v5-u-flex-direction-row-on-lg">
+        <ToolbarItem>
+          <Button
+            onClick={() => {
+              setIsOpen(true);
+            }}
+            variant={ButtonVariant.link}
+          >
+            Reset to default
+          </Button>
         </ToolbarItem>
-        <ToolbarItem spacer={{ default: 'spacerSm' }}>
-          <Stack>
-            <StackItem>
-              <Dropdown
-                isOpen={isOpen}
-                activeItemId={0}
-                onOpenChange={(isOpen: boolean) => {
-                  setIsOpen(isOpen);
-                  setChecked(isDefaultLayout(layout) ? CONSOLE_DEFAULT : CUSTOM);
-                  setCustomValueValidationError('');
-                }}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-                    Config view: {checked}
-                  </MenuToggle>
-                )}
-              >
-                <DropdownGroup label="Dashboard configuration" labelHeadingLevel="h3">
-                  <DropdownList className="pf-v5-u-pb-0">
-                    <Form>
-                      <FormGroup>
-                        <DropdownItem>
-                          <Radio
-                            name="config"
-                            id={CONSOLE_DEFAULT}
-                            label={CONSOLE_DEFAULT}
-                            value={CONSOLE_DEFAULT}
-                            onClick={(e) => {
-                              onToggleClick();
-                              setCustomValueValidationError('');
-                              setChecked(CONSOLE_DEFAULT);
-                              onDefaultConfigSubmit(e);
-                            }}
-                            checked={checked === CONSOLE_DEFAULT}
-                          ></Radio>
-                        </DropdownItem>
-                        <DropdownItem>
-                          <Radio
-                            name="config"
-                            id={CUSTOM}
-                            label="Custom configuration"
-                            value={CUSTOM}
-                            onClick={() => {
-                              setChecked(CUSTOM);
-                            }}
-                            checked={checked === CUSTOM}
-                          ></Radio>
-                          <TextArea
-                            className="pf-v5-u-mt-sm"
-                            rows={1}
-                            placeholder="Paste custom string"
-                            required
-                            onClick={() => {
-                              setChecked(CUSTOM);
-                            }}
-                            onChange={(_event, value) => {
-                              setCustomValue(value);
-                            }}
-                          ></TextArea>
-                          <FormHelperText>
-                            <HelperText>
-                              <HelperTextItem
-                                variant={customValueValidationError ? 'error' : 'default'}
-                                {...(customValueValidationError && { icon: <ExclamationCircleIcon /> })}
-                              >
-                                {customValueValidationError}
-                              </HelperTextItem>
-                            </HelperText>
-                          </FormHelperText>
-                          <div hidden={checked !== CUSTOM}>
-                            <Button variant="plain" type={ButtonType.submit} onClick={onCustomConfigSubmit}>
-                              <CheckIcon />
-                            </Button>
-                            <Button
-                              variant="plain"
-                              type={ButtonType.reset}
-                              onClick={() => {
-                                setIsOpen(false);
-                                setChecked(isDefaultLayout(layout) ? CONSOLE_DEFAULT : CUSTOM);
-                                setCustomValueValidationError('');
-                              }}
-                            >
-                              <TimesIcon />
-                            </Button>
-                          </div>
-                        </DropdownItem>
-                      </FormGroup>
-                    </Form>
-                  </DropdownList>
-                </DropdownGroup>
-              </Dropdown>
-            </StackItem>
-          </Stack>
+        <ToolbarItem className="pf-v5-u-pr-sm pf-v5-u-pr-0-on-lg pf-v5-u-pb-xs pf-v5-u-pb-0-on-lg">
+          <Button
+            onClick={() => {
+              toggleOpen((prev) => !prev);
+            }}
+            variant="secondary"
+            icon={<PlusCircleIcon />}
+          >
+            Add widgets
+          </Button>
         </ToolbarItem>
-      </Flex>
-      <ToolbarItem className="pf-v5-u-pr-sm pf-v5-u-pr-0-on-lg pf-v5-u-pb-xs pf-v5-u-pb-0-on-lg">
-        <Button
-          onClick={() => {
-            toggleOpen((prev) => !prev);
-          }}
-          variant="secondary"
-          icon={<PlusCircleIcon />}
-        >
-          Add widgets
-        </Button>
-      </ToolbarItem>
-    </ToolbarGroup>
+      </ToolbarGroup>
+    </>
   );
 };
 

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -145,6 +145,16 @@ export async function getWidgetMapping(token: string): Promise<WidgetMapping> {
   return json.data;
 }
 
+export const resetDashboardTemplate = async (type: LayoutTypes, token: string): Promise<DashboardTemplate> => {
+  const resp = await fetch(`/api/chrome-service/v1/dashboard-templates/base-template/fork${type ? `?dashboard=${type}` : ''}`, {
+    method: 'GET',
+    headers: getRequestHeaders(token),
+  });
+  handleErrors(resp);
+  const json = await resp.json();
+  return json.data;
+};
+
 export const patchDashboardTemplate = async (
   templateId: DashboardTemplate['id'],
   data: { templateConfig: PartialTemplateConfig },


### PR DESCRIPTION
[RHCLOUD-31666](https://issues.redhat.com/browse/RHCLOUD-31666)

- Added a reset option to the widget calling the `/fork` endpoint
- Removed the layout dropdown after discussion with UX, since it has no effect for now

Current state:
https://github.com/RedHatInsights/widget-layout/assets/50696716/7ca0b1ef-2b8a-4395-972b-ec4fbbc0032b

