### PR TITLE
Add class to widgets with current number of rows

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -362,7 +362,7 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
                   boxShadow: activeItem === rest.i ? '0 0 2px 2px #2684FF' : 'none',
                   ...(activeItem === rest.i ? { outline: 'none' } : {}),
                 }}
-                className={`widget-columns-${rest.w}`}
+                className={`widget-columns-${rest.w} widget-rows-${rest.h}`}
               >
                 <GridTile
                   isDragging={isDragging}


### PR DESCRIPTION
[RHCLOUD-31906](https://issues.redhat.com/browse/RHCLOUD-31906)

- Adds an additional class `widget-rows-#` to widgets with the current # of rows being occupied by the widget in order to style the widgets based on their size. This class is updated whenever the layout is changed.

Example of styling using the `widget-rows-#` and `widget-columns-#` classes:
![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/feed676d-4a09-4967-ac33-148623a0d20b)
