### PR TITLE
Make widget drawer auto-open when layout is empty

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -5,7 +5,7 @@ import ResizeHandleIcon from './resize-handle.svg';
 import GridTile, { SetWidgetAttribute } from './GridTile';
 import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isWidgetType } from '../Widgets/widgetTypes';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { currentDropInItemAtom } from '../../state/currentDropInItemAtom';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
 import { activeItemAtom, layoutAtom, layoutVariantAtom } from '../../state/layoutAtom';
@@ -46,7 +46,7 @@ const getResizeHandle = (resizeHandleAxis: string, ref: React.Ref<HTMLDivElement
 };
 
 const LayoutEmptyState = () => {
-  const [, setDrawerExpanded] = useAtom(drawerExpandedAtom);
+  const setDrawerExpanded = useSetAtom(drawerExpandedAtom);
 
   useEffect(() => {
     setDrawerExpanded(true);

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -29,6 +29,7 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon, EmptyStateVariant, PageSection } from '@patternfly/react-core';
 import { GripVerticalIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { getWidget } from '../Widgets/widgetDefaults';
+import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
 
 export const dropping_elem_id = '__dropping-elem__';
 
@@ -45,6 +46,12 @@ const getResizeHandle = (resizeHandleAxis: string, ref: React.Ref<HTMLDivElement
 };
 
 const LayoutEmptyState = () => {
+  const [, setDrawerExpanded] = useAtom(drawerExpandedAtom);
+
+  useEffect(() => {
+    setDrawerExpanded(true);
+  }, []);
+
   return (
     <PageSection className="empty-layout pf-v5-u-p-0">
       <EmptyState variant={EmptyStateVariant.lg} className="pf-v5-u-p-sm">


### PR DESCRIPTION
[RHCLOUD-31905](https://issues.redhat.com/browse/RHCLOUD-31905)

- Make widget drawer open automatically when the widget layout is empty.
![openDrawerOnEmptyLayout](https://github.com/RedHatInsights/widget-layout/assets/39098327/9cd1dd61-d43a-472f-a5ab-b7b84622c8d3)
