### PR TITLE
Fix circular dependency issues.

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const dependencies = require('./package.json').dependencies;
 
 module.exports = {
-  appUrl: ['/staging/starter'],
+  appUrl: ['/staging/widget-layout'],
   sassPrefix: '.widgetLayout, .landing',
   debug: true,
   useProxy: true,

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -31,8 +31,7 @@ import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon, EmptyStat
 import { GripVerticalIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { getWidget } from '../Widgets/widgetDefaults';
 import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
-
-export const dropping_elem_id = '__dropping-elem__';
+import { dropping_elem_id } from '../../consts';
 
 export const breakpoints = { xl: 1100, lg: 996, md: 768, sm: 480 };
 

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -1,6 +1,6 @@
 import { Layout } from 'react-grid-layout';
-import { dropping_elem_id } from '../Components/DnDLayout/GridLayout';
 import { ScalprumComponentProps } from '@scalprum/react-core';
+import { dropping_elem_id } from '../consts';
 
 const getRequestHeaders = (token: string) => ({
   Accept: 'application/json',

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,1 @@
+export const dropping_elem_id = '__dropping-elem__';


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-32227

### Why?

```
✖ Found 1 circular dependency!

1) Components/DnDLayout/GridLayout.tsx > Components/DnDLayout/GridTile.tsx > Components/Widgets/widgetDefaults.tsx > api/dashboard-templates.ts
```
There is a circular dependency between `src/Components/DnDLayout/GridLayout.tsx` and `src/api/dashboard-templates.ts` 

That leads to an issue with variable hoisting for the `patchDashboardTemplate` API method. The function is undefined when the denounced version of it is created. And that leads to failing API calls to the patch endpoint.

```
index.js:54 Uncaught TypeError: Cannot read properties of undefined (reading 'apply')
    at u (index.js:54:74)
```

### Changes

Lifted the drop element id constant to a separate file tor remove the circular dependency.