### PR TITLE
Allow widget visibility functions to be used

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -19,7 +19,6 @@ import {
   getDashboardTemplates,
   getDefaultTemplate,
   getWidgetIdentifier,
-  isOrgAdminWidgetPermissionRequired,
   mapPartialExtendedTemplateConfigToPartialTemplateConfig,
   mapTemplateConfigToExtendedTemplateConfig,
   patchDashboardTemplate,
@@ -351,11 +350,11 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
         {activeLayout
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .map(({ widgetType, title, ...rest }, index) => {
-            const { config } = getWidget(widgetMapping, widgetType);
-            const requiresOrgAdmin = isOrgAdminWidgetPermissionRequired(config);
-            if (requiresOrgAdmin && !currentUser?.is_org_admin) {
+            const widget = getWidget(widgetMapping, widgetType);
+            if (!widget) {
               return null;
             }
+            const config = widgetMapping[widgetType]?.config;
             return (
               <div
                 key={rest.i}

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -54,9 +54,15 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
   const { headerLink } = widgetConfig.config || {};
   const hasHeader = headerLink && headerLink.href && headerLink.title;
 
-  const { node, module, scope } = useMemo(() => {
+  const widgetData = useMemo(() => {
     return getWidget(widgetMapping, widgetType, () => setIsLoaded(true));
   }, [widgetMapping, widgetType]);
+
+  if (!widgetData) {
+    return null;
+  }
+
+  const { node, module, scope } = widgetData;
 
   const dropdownItems = useMemo(() => {
     const isMaximized = widgetConfig.h === widgetConfig.maxH;

--- a/src/Components/WidgetDrawer/WidgetDrawer.tsx
+++ b/src/Components/WidgetDrawer/WidgetDrawer.tsx
@@ -21,8 +21,7 @@ import { currentDropInItemAtom } from '../../state/currentDropInItemAtom';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
 import { getWidget } from '../Widgets/widgetDefaults';
 import HeaderIcon from '../Icons/HeaderIcon';
-import { WidgetConfiguration, isOrgAdminWidgetPermissionRequired } from '../../api/dashboard-templates';
-import useCurrentUser from '../../hooks/useCurrentUser';
+import { WidgetConfiguration } from '../../api/dashboard-templates';
 
 export type AddWidgetDrawerProps = React.PropsWithChildren<{
   dismissible?: boolean;
@@ -73,7 +72,6 @@ const WidgetWrapper = ({ widgetType, config }: React.PropsWithChildren<{ widgetT
 const AddWidgetDrawer = ({ children }: AddWidgetDrawerProps) => {
   const [isOpen, toggleOpen] = useAtom(drawerExpandedAtom);
   const widgetMapping = useAtomValue(widgetMappingAtom);
-  const { currentUser } = useCurrentUser();
 
   const panelContent = (
     <PageSection
@@ -102,10 +100,6 @@ const AddWidgetDrawer = ({ children }: AddWidgetDrawerProps) => {
       </Split>
       <Gallery className="widg-l-gallery pf-v5-u-pt-sm" hasGutter>
         {Object.entries(widgetMapping).map(([type, { config }], i) => {
-          const requiresOrgAdmin = isOrgAdminWidgetPermissionRequired(config);
-          if (requiresOrgAdmin && !currentUser?.is_org_admin) {
-            return null;
-          }
           return (
             <GalleryItem key={i}>
               <WidgetWrapper widgetType={type} config={config}>

--- a/src/Components/Widgets/widgetDefaults.tsx
+++ b/src/Components/Widgets/widgetDefaults.tsx
@@ -17,6 +17,9 @@ const LoadingComponent = ({ onFinishedLoading }: { onFinishedLoading?: () => voi
 
 export const getWidget = (widgetMapping: WidgetMapping, type: string, onFinishedLoading?: () => void) => {
   const mappedWidget = widgetMapping[type];
+  if (!mappedWidget) {
+    return null;
+  }
   return {
     node: mappedWidget ? <ScalprumComponent fallback={<LoadingComponent onFinishedLoading={onFinishedLoading} />} {...mappedWidget} /> : <Fragment />,
     scope: mappedWidget?.scope,

--- a/src/Routes/Default/Default.tsx
+++ b/src/Routes/Default/Default.tsx
@@ -24,12 +24,8 @@ const DefaultRoute = (props: { layoutType?: LayoutTypes }) => {
   const checkPermissions = async (permissions: WidgetPermission[]): Promise<boolean> => {
     return permissions.every(async (permission) => {
       const { method, args } = permission;
-      if (visibilityFunctions[method]) {
-        const visibilityFunction = visibilityFunctions[method];
-
-        if (typeof visibilityFunction === 'function') {
-          return await (visibilityFunction as (...args: unknown[]) => Promise<boolean>)(...(args || []));
-        }
+      if (visibilityFunctions[method] && typeof visibilityFunctions[method] === 'function') {
+        return await (visibilityFunctions[method] as (...args: unknown[]) => Promise<boolean>)(...(args || []));
       }
 
       return true;

--- a/src/Routes/Default/Default.tsx
+++ b/src/Routes/Default/Default.tsx
@@ -7,10 +7,11 @@ import { notificationsAtom, useRemoveNotification } from '../../state/notificati
 import Header from '../../Components/Header/Header';
 import React, { useEffect } from 'react';
 import useCurrentUser from '../../hooks/useCurrentUser';
-import { LayoutTypes, getWidgetMapping } from '../../api/dashboard-templates';
+import { LayoutTypes, WidgetPermission, getWidgetMapping } from '../../api/dashboard-templates';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
 import '../../App.scss';
 import Portal from '@redhat-cloud-services/frontend-components-notifications/Portal';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const DefaultRoute = (props: { layoutType?: LayoutTypes }) => {
   const isLayoutLocked = useAtomValue(lockedLayoutAtom);
@@ -18,18 +19,48 @@ const DefaultRoute = (props: { layoutType?: LayoutTypes }) => {
   const removeNotification = useRemoveNotification();
   const setWidgetMapping = useSetAtom(widgetMappingAtom);
   const { currentUser } = useCurrentUser();
+  const { visibilityFunctions } = useChrome();
+
+  const checkPermissions = async (permissions: WidgetPermission[]): Promise<boolean> => {
+    console.log('Checking permissions: ', permissions);
+    for (const permission of permissions) {
+      if (permission.method === 'permissions' && permission.args && !(await visibilityFunctions.hasPermissions(permission.args))) {
+        return false;
+      }
+
+      if (permission.method === 'loosePermissions' && permission.args && !(await visibilityFunctions.loosePermissions(permission.args))) {
+        return false;
+      }
+
+      if (permission.method === 'isOrgAdmin' && !(await visibilityFunctions.isOrgAdmin())) {
+        return false;
+      }
+    }
+
+    return true;
+  };
 
   useEffect(() => {
     if (!currentUser) {
       return;
     }
-    const getWidgetMap = async () => {
-      const mapping = await getWidgetMapping();
-      if (mapping) {
-        setWidgetMapping(mapping);
-      }
-    };
-    getWidgetMap();
+
+    (async () => {
+      const getWidgetMap = async () => {
+        const mapping = await getWidgetMapping();
+        if (mapping) {
+          for (const key of Object.keys(mapping)) {
+            const widgetConfig = mapping[key].config;
+            if (widgetConfig && widgetConfig.permissions && !(await checkPermissions(widgetConfig.permissions as WidgetPermission[]))) {
+              delete mapping[key]; // remove widget from mapping if user does not have permissions for it
+            }
+          }
+          setWidgetMapping(mapping);
+        }
+      };
+
+      await getWidgetMap();
+    })();
   }, [currentUser]);
 
   return (

--- a/src/Routes/Default/Default.tsx
+++ b/src/Routes/Default/Default.tsx
@@ -24,12 +24,17 @@ const DefaultRoute = (props: { layoutType?: LayoutTypes }) => {
   const checkPermissions = async (permissions: WidgetPermission[]): Promise<boolean> => {
     const permissionResults = await Promise.all(
       permissions.map(async (permission) => {
-        const { method, args } = permission;
-        if (visibilityFunctions[method] && typeof visibilityFunctions[method] === 'function') {
-          const permissionGranted = await (visibilityFunctions[method] as (...args: unknown[]) => Promise<boolean>)(...(args || []));
-          return permissionGranted;
+        try {
+          const { method, args } = permission;
+          if (visibilityFunctions[method] && typeof visibilityFunctions[method] === 'function') {
+            const permissionGranted = await (visibilityFunctions[method] as (...args: unknown[]) => Promise<boolean>)(...(args || []));
+            return permissionGranted;
+          }
+          return true;
+        } catch (error) {
+          console.error('Error checking permissions', error);
+          return false;
         }
-        return true;
       })
     );
     return permissionResults.every(Boolean);

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -1,6 +1,7 @@
 import { Layout } from 'react-grid-layout';
 import { ScalprumComponentProps } from '@scalprum/react-core';
 import { dropping_elem_id } from '../consts';
+import { VisibilityFunctions } from '@redhat-cloud-services/types';
 
 const getRequestHeaders = () => ({
   Accept: 'application/json',
@@ -86,14 +87,11 @@ export type WidgetHeaderLink = {
   href?: string;
 };
 
-export type WidgetPermission = {
-  method?: string;
-  apps?: string[];
-  args?: string[];
-};
+type VisibilityFunctionKeys = keyof VisibilityFunctions;
 
-export const orgAdminWidgetPermission: WidgetPermission = {
-  method: 'isOrgAdmin',
+export type WidgetPermission = {
+  method: VisibilityFunctionKeys;
+  args?: Parameters<VisibilityFunctions[VisibilityFunctionKeys]>;
 };
 
 export type WidgetConfiguration = {

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -89,7 +89,7 @@ export type WidgetHeaderLink = {
 export type WidgetPermission = {
   method?: string;
   apps?: string[];
-  args?: unknown[];
+  args?: string[];
 };
 
 export const orgAdminWidgetPermission: WidgetPermission = {
@@ -233,9 +233,4 @@ export const mapPartialExtendedTemplateConfigToPartialTemplateConfig = (
     result[key] = extendedTemplateConfig[key]?.map(mapExtendedLayoutToLayoutWithTitle).filter(({ i }) => i !== dropping_elem_id);
   });
   return result;
-};
-
-export const isOrgAdminWidgetPermissionRequired = (config: WidgetConfiguration | undefined): boolean => {
-  const orgAdminPermissionIndex = config?.permissions?.findIndex((permission) => permission?.method === orgAdminWidgetPermission.method);
-  return orgAdminPermissionIndex !== undefined && orgAdminPermissionIndex > -1;
 };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Check the permissions defined in the backend widget configuration using chrome's `visibilityFunctions`. Remove widgets from the layout and widget drawer that the user does not have permissions to use.

[RHCLOUD-32312](https://issues.redhat.com/browse/RHCLOUD-32312)

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [X] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
