### PR TITLE
Update icon styling

### DIFF
--- a/src/Components/DnDLayout/GridTile.scss
+++ b/src/Components/DnDLayout/GridTile.scss
@@ -21,8 +21,16 @@
       &:first-child {
         padding-top: var(--pf-v5-global--spacer--md);
       }
-      .pf-v5-c-icon {
-        --pf-v5-c-icon__content--m-custom--Color: var(--pf-v5-global--primary-color--100);
+      .widg-c-icon--header {
+        .service-icon {
+          height: 28px;
+          width: 28px;
+        }
+        .pf-v5-svg {
+          color: var(--pf-v5-global--primary-color--100);
+          height: 22px;
+          width: 22px;     
+        }
       }
     }
   }

--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -164,15 +164,15 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
       <CardHeader actions={{ actions: headerActions }}>
         <Flex>
           <Flex className="pf-v5-u-flex-direction-row pf-v5-u-flex-nowrap">
-            <Icon status="custom" className="pf-v5-u-mr-sm">
+            <div className="pf-v5-u-align-self-flex-start widg-c-icon--header pf-v5-u-mr-sm">
               {isLoaded ? <HeaderIcon icon={widgetConfig?.config?.icon} /> : <Skeleton shape="circle" width="25px" height="25px" />}
-            </Icon>
+            </div>
             {isLoaded ? (
               <CardTitle
                 style={{
                   userSelect: isDragging ? 'none' : 'auto',
                 }}
-                className="pf-v5-u-flex-wrap pf-v5-u-text-break-word"
+                className="pf-v5-u-align-self-flex-start"
               >
                 {widgetConfig?.config?.title || widgetType}
               </CardTitle>
@@ -180,6 +180,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
               <Skeleton width="50%" />
             )}
           </Flex>
+
           {hasHeader && isLoaded && (
             <FlexItem>
               <Button className="widget-header-link pf-v5-u-pl-lg pf-v5-u-p-0" variant="link" onClick={() => window.open(headerLink.href, '_blank')}>

--- a/src/Components/Icons/images/ACSIcon.tsx
+++ b/src/Components/Icons/images/ACSIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ACSIcon = () => {
   return (
-    <svg width="20" height="20" viewBox="0 0 38 38">
+    <svg className="service-icon" viewBox="0 0 38 38">
       <defs>
         <style>{`.uuid-2cc71784-83b2-4ce0-a27c-c558cca16f2a{fill:#e00;}.uuid-073bfd7c-dff4-432f-a7b0-f3a025d959a1{fill:#fff;}`}</style>
       </defs>

--- a/src/Components/Icons/images/AnsibleIcon.tsx
+++ b/src/Components/Icons/images/AnsibleIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const AnsibleIcon = () => {
   return (
-    <svg width="20" height="20" viewBox="0 0 38 38">
+    <svg className="service-icon" viewBox="0 0 38 38">
       <defs>
         <style>{`.a{fill:#fff;}.b{fill:#e00;}`}</style>
       </defs>

--- a/src/Components/Icons/images/EdgeIcon.tsx
+++ b/src/Components/Icons/images/EdgeIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const EdgeIcon = () => {
   return (
-    <svg width="20" height="20" viewBox="0 0 42 42">
+    <svg className="service-icon" viewBox="0 0 42 42">
       <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="Group-8" fillRule="nonzero">
           <path

--- a/src/Components/Icons/images/OpenShiftAIIcon.tsx
+++ b/src/Components/Icons/images/OpenShiftAIIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const OpenShiftAiIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 38 38">
+    <svg className="service-icon" viewBox="0 0 38 38">
       <g id="uuid-fb69441b-b57f-4918-99bb-aad41e7175f0">
         <rect x="1" y="1" width="36" height="36" rx="9" ry="9" strokeWidth="0" />
         <path

--- a/src/Components/Icons/images/OpenShiftIcon.tsx
+++ b/src/Components/Icons/images/OpenShiftIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const OpenShiftIcon = () => {
   return (
-    <svg width="20" height="20" viewBox="0 0 38 38">
+    <svg className="service-icon" viewBox="0 0 38 38">
       <defs>
         <style>
           {`.a{fill:#fff;}`}

--- a/src/Components/Icons/images/QuayIcon.tsx
+++ b/src/Components/Icons/images/QuayIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const QuayIcon = () => {
   return (
-    <svg width="20" height="20" viewBox="0 0 38 38">
+    <svg className="service-icon" viewBox="0 0 38 38">
       <g id="Symbols" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="Technology_icon-Red_Hat-Quay-Standard-RGB" fillRule="nonzero">
           <g id="uuid-16df5206-ca64-41dd-b57e-55c66370cb99" fill="#000000">

--- a/src/Components/Icons/images/RhelIcon.tsx
+++ b/src/Components/Icons/images/RhelIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const RhelIcon = () => {
   return (
-    <svg width="20" height="20" viewBox="0 0 52 52">
+    <svg className="service-icon" viewBox="0 0 52 52">
       <g id="Widgets" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="Icons-/-1.-Size-md-/-Object-/-star" fillRule="nonzero">
           <path


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
This PR adds separate classes for PF icons vs product SVGs so they can be sized differently. It also better aligns the icons with the Title

[RHCLOUD-32327](https://issues.redhat.com/browse/RHCLOUD-32327)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2024-04-29 at 12 57 20 PM](https://github.com/RedHatInsights/widget-layout/assets/1287144/17027687-88d2-4aec-a43f-efab9163feea)


#### After:
[
![Screenshot 2024-04-29 at 12 56 21 PM](https://github.com/RedHatInsights/widget-layout/assets/1287144/7b73f53d-4e1e-42ac-becf-0e26a52445b2)
](url)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
