### PR TITLE
Filter out widgets from drawer that are already used in dashboard

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -30,6 +30,7 @@ import { getWidget } from '../Widgets/widgetDefaults';
 import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
 import { columns, dropping_elem_id } from '../../consts';
 import { useAddNotification } from '../../state/notificationsAtom';
+import { currentlyUsedWidgetsAtom } from '../../state/currentlyUsedWidgetsAtom';
 
 export const breakpoints = { xl: 1100, lg: 996, md: 768, sm: 480 };
 
@@ -85,6 +86,7 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
   const { currentUser } = useCurrentUser();
   const widgetMapping = useAtomValue(widgetMappingAtom);
   const addNotification = useAddNotification();
+  const setCurrentlyUsedWidgets = useSetAtom(currentlyUsedWidgetsAtom);
 
   const [currentDropInItem, setCurrentDropInItem] = useAtom(currentDropInItemAtom);
   const droppingItemTemplate: ReactGridLayoutProps['droppingItem'] = useMemo(() => {
@@ -172,6 +174,7 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
   const onLayoutChange: ResponsiveProps['onLayoutChange'] = async (currentLayout: Layout[]) => {
     if (isInitialRender) {
       setIsInitialRender(false);
+      setCurrentlyUsedWidgets(activeLayout.map((item) => item.widgetType));
       return;
     }
     if (isLayoutLocked || templateId < 0 || !layoutVariant || currentDropInItem) {
@@ -179,6 +182,7 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
     }
 
     const data = mapPartialExtendedTemplateConfigToPartialTemplateConfig({ ...template, [layoutVariant]: currentLayout });
+    setCurrentlyUsedWidgets(activeLayout.map((item) => item.widgetType));
 
     try {
       const template = await debouncedPatchDashboardTemplate(templateId, { templateConfig: data });

--- a/src/Components/WidgetDrawer/WidgetDrawer.tsx
+++ b/src/Components/WidgetDrawer/WidgetDrawer.tsx
@@ -22,6 +22,7 @@ import { widgetMappingAtom } from '../../state/widgetMappingAtom';
 import { getWidget } from '../Widgets/widgetDefaults';
 import HeaderIcon from '../Icons/HeaderIcon';
 import { WidgetConfiguration } from '../../api/dashboard-templates';
+import { currentlyUsedWidgetsAtom } from '../../state/currentlyUsedWidgetsAtom';
 
 export type AddWidgetDrawerProps = React.PropsWithChildren<{
   dismissible?: boolean;
@@ -72,6 +73,9 @@ const WidgetWrapper = ({ widgetType, config }: React.PropsWithChildren<{ widgetT
 const AddWidgetDrawer = ({ children }: AddWidgetDrawerProps) => {
   const [isOpen, toggleOpen] = useAtom(drawerExpandedAtom);
   const widgetMapping = useAtomValue(widgetMappingAtom);
+  const currentlyUsedWidgets = useAtomValue(currentlyUsedWidgetsAtom);
+
+  const filteredWidgetMapping = Object.entries(widgetMapping).filter(([type]) => !currentlyUsedWidgets.includes(type));
 
   const panelContent = (
     <PageSection
@@ -99,7 +103,7 @@ const AddWidgetDrawer = ({ children }: AddWidgetDrawerProps) => {
         </SplitItem>
       </Split>
       <Gallery className="widg-l-gallery pf-v5-u-pt-sm" hasGutter>
-        {Object.entries(widgetMapping).map(([type, { config }], i) => {
+        {filteredWidgetMapping.map(([type, { config }], i) => {
           return (
             <GalleryItem key={i}>
               <WidgetWrapper widgetType={type} config={config}>

--- a/src/state/currentlyUsedWidgetsAtom.ts
+++ b/src/state/currentlyUsedWidgetsAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const currentlyUsedWidgetsAtom = atom<string[]>([]);


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Configure widget drawer so that the user can only ever drag out one instance of a widget type onto their dashboard. Widget types that are already used in the dashboard should not be displayed in the widget drawer.

[RHCLOUD-32108](https://issues.redhat.com/browse/RHCLOUD-32108)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/ff8654ae-bab3-4068-85f2-ad7761adaafb)


#### After:
![image](https://github.com/RedHatInsights/widget-layout/assets/39098327/8ed438d6-dc2d-4851-b752-89dbd4b2d279)


---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [X] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
