### PR TITLE
RHCLOUD-32770: OUIA IDs for locating individual widget elements

### DIFF
--- a/src/Components/DnDLayout/GridTile.tsx
+++ b/src/Components/DnDLayout/GridTile.tsx
@@ -70,6 +70,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
     return (
       <>
         <DropdownItem
+          ouiaId={`${scope}-${widgetType}-widget`}
           onClick={() => {
             setIsOpen(false);
             setWidgetAttribute(widgetConfig.i, 'static', !widgetConfig.static);
@@ -79,6 +80,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
           {widgetConfig.static ? 'Unlock location and size' : 'Lock location and size'}
         </DropdownItem>
         <DropdownItem
+          ouiaId={`${scope}-${widgetType}-widget`}
           isDisabled={isMaximized || widgetConfig.static}
           onClick={() => {
             setWidgetAttribute(widgetConfig.i, 'h', widgetConfig.maxH ?? widgetConfig.h);
@@ -89,6 +91,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
           Autosize height to content
         </DropdownItem>
         <DropdownItem
+          ouiaId={`${scope}-${widgetType}-widget`}
           onClick={() => {
             setWidgetAttribute(widgetConfig.i, 'h', widgetConfig.minH ?? widgetConfig.h);
             setIsOpen(false);
@@ -99,6 +102,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
           Minimize height
         </DropdownItem>
         <DropdownItem
+          ouiaId={`${scope}-${widgetType}-widget`}
           onClick={() => {
             removeWidget(widgetConfig.i);
           }}
@@ -124,6 +128,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
     <>
       <Tooltip content={<p>Actions</p>}>
         <Dropdown
+          ouiaId={`${scope}-${widgetType}-widget`}
           popperProps={{
             appendTo: document.body,
             maxWidth: '300px',
@@ -135,7 +140,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
               isExpanded={isOpen}
               onClick={() => setIsOpen((prev) => !prev)}
               variant="plain"
-              aria-label="Card title inline with images and actions example kebab toggle"
+              aria-label="widget actions menu toggle"
             >
               <EllipsisVIcon aria-hidden="true" />
             </MenuToggle>
@@ -146,7 +151,7 @@ const GridTile = ({ widgetType, isDragging, setIsDragging, setWidgetAttribute, w
           <DropdownList>{dropdownItems}</DropdownList>
         </Dropdown>
       </Tooltip>
-      <Tooltip content={<p>{widgetConfig.static ? 'Widget locked' : 'Move'}</p>}>
+      <Tooltip aria-label="Move widget" content={<p>{widgetConfig.static ? 'Widget locked' : 'Move'}</p>}>
         <Icon
           onMouseDown={() => setIsDragging(true)}
           onMouseUp={() => setIsDragging(false)}


### PR DESCRIPTION
### Description

Adds OUIA IDs for individual widget elements so that test automation can locate and interact with them. Previous tests have used some lengthy, contrived selectors that will be prone to breakage in the future. This should help avoid similar issues in future widgets-related tests.

[RHCLOUD-32770](https://issues.redhat.com/browse/RHCLOUD-32770)

---

### Screenshots
N/A

#### Before:
N/A

#### After:
N/A

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
