### PR TITLE
Add support for itless base layout dashboard type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@patternfly/react-core": "^5.3.3",
         "@redhat-cloud-services/frontend-components": "^4.2.11",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
+        "@unleash/proxy-client-react": "^3.6.0",
         "awesome-debounce-promise": "^2.1.0",
         "classnames": "^2.5.1",
         "jotai": "^2.8.4",
@@ -5743,6 +5744,14 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@unleash/proxy-client-react": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.6.0.tgz",
+      "integrity": "sha512-maQ3PYdBWUpIraD9z/2C8oVoCAS/EryV0WT4HiZQWxzrwvrZ+XHQJw1sImzRdWlGMvl1qJcgdEoxXhNSuYIrEQ==",
+      "peerDependencies": {
+        "unleash-proxy-client": "^2.5.0"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -20432,6 +20441,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "peer": true
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -21106,6 +21121,16 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unleash-proxy-client": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz",
+      "integrity": "sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==",
+      "peer": true,
+      "dependencies": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@patternfly/react-core": "^5.3.3",
     "@redhat-cloud-services/frontend-components": "^4.2.11",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
+    "@unleash/proxy-client-react": "^3.6.0",
     "awesome-debounce-promise": "^2.1.0",
     "classnames": "^2.5.1",
     "jotai": "^2.8.4",

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -41,6 +41,7 @@ import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
 import { columns, dropping_elem_id } from '../../consts';
 import { useAddNotification } from '../../state/notificationsAtom';
 import { currentlyUsedWidgetsAtom } from '../../state/currentlyUsedWidgetsAtom';
+import { useFlag } from '@unleash/proxy-client-react';
 
 export const breakpoints: {
   [key in Variants]: number;
@@ -100,6 +101,12 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
   const addNotification = useAddNotification();
   const setCurrentlyUsedWidgets = useSetAtom(currentlyUsedWidgetsAtom);
   const { analytics } = useChrome();
+  const isITLess = useFlag('platform.widget-layout.itless');
+  let targetLayout = layoutType;
+
+  if (layoutType === 'landingPage' && isITLess) {
+    targetLayout = 'landingPageItless';
+  }
 
   const [currentDropInItem, setCurrentDropInItem] = useAtom(currentDropInItemAtom);
   const droppingItemTemplate: ReactGridLayoutProps['droppingItem'] = useMemo(() => {
@@ -207,7 +214,7 @@ const GridLayout = ({ isLayoutLocked = false, layoutType = 'landingPage' }: { is
       return;
     }
     // TODO template type should be pulled from app config for reusability
-    getDashboardTemplates(layoutType)
+    getDashboardTemplates(targetLayout)
       .then((templates) => {
         const customDefaultTemplate = getDefaultTemplate(templates);
         if (!customDefaultTemplate) {

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -10,7 +10,7 @@ const getRequestHeaders = () => ({
 
 export const widgetIdSeparator = '#';
 
-export type LayoutTypes = 'landingPage';
+export type LayoutTypes = 'landingPage' | 'landingPageItless';
 
 export type Variants = 'sm' | 'md' | 'lg' | 'xl';
 


### PR DESCRIPTION
We recently updated chrome-service backend to remove widgets from the widget mapping based on feature flag (see: https://github.com/RedHatInsights/chrome-service-backend/pull/716). However, those widgets still appear in the forked base template. The widgets are not rendered by the UI - however there are large chunks of whitespace in the grid (where those widgets would have been).

There are a few options to resolve this:
1. Have the UI immediately turn around and `patch` the layout to remove these items. IMO this could cause undesirable bugs however (how do we know when a widget should actually be removed or there is a configuration issue?)
2. Use the existing base template but remove each widget from the base template when the feature flag is enabled. This will cause us to make a second round trip to the server (unless cached) for the flags, and also requires us to iterate over every template variant (`sm`, `md`, etc) for the widgets (unless we add a new item to the schema).
3. (This PR) add a new forkable landing page layout specific to itless

![image](https://github.com/user-attachments/assets/6245bc36-6a14-413e-8628-91ce2a943e1c)
