### PR TITLE
Add error handling to setDragImage to unblock cypress tests

### DIFF
--- a/src/Components/WidgetDrawer/WidgetDrawer.tsx
+++ b/src/Components/WidgetDrawer/WidgetDrawer.tsx
@@ -44,13 +44,20 @@ const WidgetWrapper = ({ widgetType, config }: React.PropsWithChildren<{ widgetT
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const nodeRect = e.target.getBoundingClientRect();
-        e.dataTransfer.setDragImage(
-          e.target as HTMLDivElement,
-          // mess with this to set the drag image and proper mouse position
-          e.clientX - nodeRect.left,
-          e.clientY - nodeRect.top
-        );
-        e.dataTransfer.setData('text', widgetType);
+
+        if (e.dataTransfer) {
+          e.dataTransfer.setDragImage(
+            e.target as HTMLDivElement,
+            // mess with this to set the drag image and proper mouse position
+            e.clientX - nodeRect.left,
+            e.clientY - nodeRect.top
+          );
+        }
+
+        if (e.dataTransfer) {
+          e.dataTransfer.setData('text', widgetType);
+        }
+
         setDropInItem(widgetType);
       }}
       onDragEnd={() => setDropInItem(undefined)}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Add error handling to setDragImage as this is giving a console error during cypress test runs for the integrations tests when attempting to add a widget to the widget dashboard via test automation.

CURRENTLY a draft as this has not been tested yet

[RHCLOUD37447](https://issues.redhat.com/browse/RHCLOUD37447)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
