### PR TITLE
chore: Update stale workflow to use shared workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,16 +1,9 @@
-name: 'Close stale issues and PRs'
+name: Handle stale issues
+
 on:
   schedule:
     - cron: '30 1 * * *'
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        with:
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. If you do not remove the "stale" label or comment, this will be closed in 5 days.'
-          days-before-stale: 60
-          days-before-close: 5
-          exempt-issue-labels: 'work-in-progress, in-progress, in-review, help-wanted, blocked, wip, depfu, dependabot, dependencies'
-          exempt-draft-pr: true
+    uses: RedHatInsights/shared-workflows/.github/workflows/stale.yml@master

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Handle stale issues
+name: Handle stale issues and PRs
 
 on:
   schedule:


### PR DESCRIPTION
### Description
Update the stale workflow to use the one in the shared-workflows repo

## Summary by Sourcery

CI:
- Update GitHub Actions workflow to use a centralized stale issues workflow from a shared repository