### PR TITLE
FEO Migration

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -12,6 +12,7 @@ objects:
     spec:
       envName: ${ENV_NAME}
       title: widget-layout
+      feoConfigEnabled: true
       deploymentRepo: https://github.com/RedHatInsights/widget-layout
       API:
         versions:
@@ -21,12 +22,12 @@ objects:
           - /apps/widget-layout
       image: ${IMAGE}:${IMAGE_TAG}
       module:
-        manifestLocation: "/apps/widget-layout/fed-mods.json"
+        manifestLocation: /apps/widget-layout/fed-mods.json
         modules:
-          - id: "widgetLayout"
-            module: "./RootApp"
+          - id: widgetLayout
+            module: ./RootApp
             routes: 
-            - pathname: "/staging/widget-layout"
+            - pathname: /staging/widget-layout
 
 parameters:
   - name: ENV_NAME

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+---
 apiVersion: v1
 kind: Template
 metadata:

--- a/fec.config.js
+++ b/fec.config.js
@@ -4,6 +4,7 @@ const dependencies = require('./package.json').dependencies;
 module.exports = {
   appUrl: ['/staging/widget-layout'],
   sassPrefix: '.widgetLayout, .landing',
+  frontendCRDPath: path.resolve(__dirname, './deploy/frontend.yaml'),
   debug: true,
   useProxy: true,
   proxyVerbose: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.4",
-        "@redhat-cloud-services/frontend-components-config": "^6.4.9",
+        "@redhat-cloud-services/frontend-components-config": "^6.5.0",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.12",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.3.1",
@@ -3548,14 +3548,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.4.9.tgz",
-      "integrity": "sha512-hCMxsi/DG11di+6Myp9Ih1nVbYWFO2O1uXZD4ksM3GIQpuXQSseW5eDKvqGgPDgHVKOGfXrLWo4q2jqvG4bnZA==",
+      "version": "6.5.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.5.9.tgz",
+      "integrity": "sha512-7WpREajUCfv+XNDdx0LmnqWcP/Fak8E5V3X7BcwB8FIJFa3/MpHR20MMC0HBGElLe05vBOOXz+EXfhRcEn3Peg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^4.1.6",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^4.3.4",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
@@ -3602,9 +3602,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.1.6.tgz",
-      "integrity": "sha512-cO9ssCR9lpbT4PuPPwD5Ug96O/d0FyA5lPuouWUxwwdHr+DeZU8ejeCW/PaslHwv/9hfEkbckEcRn9lk0Q8lhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.3.4.tgz",
+      "integrity": "sha512-+d+szjdSaoi6qtqIxzQ3gtJYG10S/ENTuxUFaJ1jyHvvxrgjKp1scw94SrREV4eh4I96JOIOdU6s2auWUA0jlg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.4",
-    "@redhat-cloud-services/frontend-components-config": "^6.4.9",
+    "@redhat-cloud-services/frontend-components-config": "^6.5.0",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.12",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",


### PR DESCRIPTION
For [RHCLOUD-39265](https://issues.redhat.com/browse/RHCLOUD-39265). Seems like minimal changes are necessary as the module matches the fed-mods in chrome-service and there's no nav