### PR TITLE
RHCLOUD-45017 [UI a11y] Widget corner img elements lack alt text

### DIFF
--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -43,7 +43,7 @@ const documentationLink =
 const getResizeHandle = (resizeHandleAxis: string, ref: React.Ref<HTMLDivElement>) => {
   return (
     <div ref={ref} className={`react-resizable-handle react-resizable-handle-${resizeHandleAxis}`}>
-      <img src={ResizeHandleIcon} alt='' />
+      <img src={ResizeHandleIcon} alt="" />
     </div>
   );
 };


### PR DESCRIPTION
### Description

Solves an easy accessibility problem by adding an empty `alt` attribute to the `<img>` elements that form the rounded corners of each widget's tile.

[RHCLOUD-45017](https://issues.redhat.com/browse/RHCLOUD-45017)

---

### Screenshots
Results are perceptible only to users who do not use a screen reader.

#### Before:
Screen reader users will must listen to 16 repetitions of "unlabeled image slash resize handle S V G" as they navigate the widget layout area.

#### After:
Screen readers will skip these images entirely.

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [x] _(Optional) QE: Needs QE attention (we should include a check for alt-less images in our usual QE)_
- [x] _(Optional) QE: Has been mentioned_
- [x] _(Optional) UX: Needs UX attention (UX improved for a subset of end users)_
- [x] _(Optional) UX: Has been mentioned_
##
