### PR TITLE
feat: add dashboard duplicate feature

### DIFF
--- a/cypress/component/DuplicateModal.cy.tsx
+++ b/cypress/component/DuplicateModal.cy.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import { DuplicateModal } from '../../src/Components/DuplicateModal/DuplicateModal';
+import Portal from '@redhat-cloud-services/frontend-components-notifications/Portal';
+import { useAtomValue } from 'jotai';
+import { notificationsAtom, useRemoveNotification } from '../../src/state/notificationsAtom';
+
+const NotificationPortal = () => {
+  const notifications = useAtomValue(notificationsAtom);
+  const removeNotification = useRemoveNotification();
+  return <Portal notifications={notifications} removeNotification={removeNotification} />;
+};
+
+const mockDashboards = [
+  {
+    id: 1,
+    createdAt: '2025-01-01',
+    updatedAt: '2025-01-01',
+    deletedAt: null,
+    userIdentityID: 1,
+    default: true,
+    templateBase: { name: 'landingPage', displayName: 'Landing Page' },
+    templateConfig: { sm: [], md: [], lg: [], xl: [] },
+    dashboardName: 'Dashboard One',
+  },
+  {
+    id: 2,
+    createdAt: '2025-01-02',
+    updatedAt: '2025-01-02',
+    deletedAt: null,
+    userIdentityID: 1,
+    default: false,
+    templateBase: { name: 'landingPage', displayName: 'Landing Page' },
+    templateConfig: { sm: [], md: [], lg: [], xl: [] },
+    dashboardName: 'Dashboard Two',
+  },
+];
+
+const mockCopyResponse = {
+  id: 99,
+  createdAt: '2025-02-01T00:00:00Z',
+  updatedAt: '2025-02-01T00:00:00Z',
+  deletedAt: null,
+  userIdentityID: 1,
+  default: false,
+  templateBase: { name: 'landingPage', displayName: 'Landing Page' },
+  templateConfig: { sm: [], md: [], lg: [], xl: [] },
+  dashboardName: 'My Duplicate',
+};
+
+describe('DuplicateModal', () => {
+
+  it('renders modal with title when isOpen=true', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.contains('Duplicate existing dashboard').should('be.visible');
+  });
+
+  it('does not render modal content when isOpen=false', () => {
+    cy.mount(<DuplicateModal isOpen={false} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.contains('Duplicate existing dashboard').should('not.exist');
+  });
+
+  it('shows "Duplicate dashboard" button disabled when form is empty', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.contains('button', 'Duplicate dashboard').should('be.visible').and('be.disabled');
+  });
+
+  it('Cancel button calls onClose', () => {
+    const onClose = cy.stub().as('onClose');
+    cy.mount(<DuplicateModal isOpen={true} onClose={onClose} dashboards={mockDashboards} />);
+    cy.contains('button', 'Cancel').click();
+    cy.get('@onClose').should('have.been.calledOnce');
+  });
+
+  it('dashboard name input is present and can be typed into', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('#duplicate-dashboard-name')
+      .should('be.visible')
+      .type('My Duplicate')
+      .should('have.value', 'My Duplicate');
+  });
+
+  it('form labels are correct', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.contains('label', 'Select existing dashboard for duplication').should('be.visible');
+    cy.contains('label', 'New dashboard name').should('be.visible');
+    cy.contains('Set as homepage').should('be.visible');
+  });
+
+  it('checkbox is unchecked by default and can be toggled', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('#set-as-homepage').should('not.be.checked');
+    cy.get('#set-as-homepage').check();
+    cy.get('#set-as-homepage').should('be.checked');
+    cy.get('#set-as-homepage').uncheck();
+    cy.get('#set-as-homepage').should('not.be.checked');
+  });
+
+  it('dashboard select dropdown shows mocked dashboards', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('select[aria-label="Select a dashboard"]').within(() => {
+      cy.get('option').should('have.length', 3); // placeholder + 2 dashboards
+      cy.contains('option', 'Dashboard One').should('exist');
+      cy.contains('option', 'Dashboard Two').should('exist');
+    });
+  });
+
+  it('enables "Duplicate dashboard" button when both dashboard is selected AND name is entered', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('select[aria-label="Select a dashboard"]').select('1');
+    cy.get('#duplicate-dashboard-name').type('My Duplicate');
+    cy.contains('button', 'Duplicate dashboard').should('not.be.disabled');
+  });
+
+  it('keeps button disabled when only name is entered (no dashboard selected)', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('#duplicate-dashboard-name').type('My Duplicate');
+    cy.contains('button', 'Duplicate dashboard').should('be.disabled');
+  });
+
+  it('keeps button disabled when only dashboard is selected (no name)', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('select[aria-label="Select a dashboard"]').select('1');
+    cy.contains('button', 'Duplicate dashboard').should('be.disabled');
+  });
+
+  it('keeps button disabled when name is whitespace only', () => {
+    cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+    cy.get('select[aria-label="Select a dashboard"]').select('1');
+    cy.get('#duplicate-dashboard-name').type('   ');
+    cy.contains('button', 'Duplicate dashboard').should('be.disabled');
+  });
+
+  describe('Successful duplication', () => {
+    it('calls copy API, shows success notification, calls onSuccess and onClose', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 200,
+        body: mockCopyResponse,
+      }).as('copyDashboard');
+
+      const onClose = cy.stub().as('onClose');
+      const onSuccess = cy.stub().as('onSuccess');
+
+      cy.mount(
+        <>
+          <NotificationPortal />
+          <DuplicateModal isOpen={true} onClose={onClose} onSuccess={onSuccess} dashboards={mockDashboards} />
+        </>
+      );
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      cy.wait('@copyDashboard');
+
+      cy.get('@onSuccess').should('have.been.calledOnce');
+      cy.get('@onClose').should('have.been.calledOnce');
+      cy.get('.pf-v6-c-alert').should('contain.text', "Dashboard 'My Duplicate' duplicated successfully");
+    });
+
+    it('calls setDefaultTemplate API when "Set as homepage" is checked', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 200,
+        body: mockCopyResponse,
+      }).as('copyDashboard');
+
+      cy.intercept('POST', '/api/widget-layout/v1/99/default', {
+        statusCode: 200,
+        body: { ...mockCopyResponse, default: true },
+      }).as('setDefault');
+
+      const onClose = cy.stub().as('onClose');
+
+      cy.mount(
+        <>
+          <NotificationPortal />
+          <DuplicateModal isOpen={true} onClose={onClose} onSuccess={cy.stub()} dashboards={mockDashboards} />
+        </>
+      );
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.get('#set-as-homepage').check();
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      cy.wait('@copyDashboard');
+      cy.wait('@setDefault');
+
+      cy.get('@onClose').should('have.been.calledOnce');
+    });
+
+    it('does not call setDefaultTemplate when checkbox is unchecked', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 200,
+        body: mockCopyResponse,
+      }).as('copyDashboard');
+
+      cy.intercept('POST', '/api/widget-layout/v1/99/default', {
+        statusCode: 200,
+        body: { ...mockCopyResponse, default: true },
+      }).as('setDefault');
+
+      cy.mount(
+        <>
+          <NotificationPortal />
+          <DuplicateModal isOpen={true} onClose={cy.stub()} onSuccess={cy.stub()} dashboards={mockDashboards} />
+        </>
+      );
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      cy.wait('@copyDashboard');
+
+      // Ensure setDefault was NOT called
+      cy.get('@setDefault.all').should('have.length', 0);
+    });
+  });
+
+  describe('Loading state', () => {
+    it('shows "Duplicating..." and disables buttons during submission', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 200,
+        body: mockCopyResponse,
+        delay: 1000,
+      }).as('copyDashboard');
+
+      cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      // While loading
+      cy.contains('button', 'Duplicating...').should('be.visible').and('be.disabled');
+      cy.contains('button', 'Cancel').should('be.disabled');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('shows error alert for 500+ status', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 500,
+        body: 'Internal Server Error',
+      }).as('copyDashboard');
+
+      cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      cy.wait('@copyDashboard');
+
+      cy.get('.pf-v6-c-alert').should('contain.text', 'The server is currently unavailable. Please try again later.');
+    });
+
+    it('shows error alert for non-500 errors', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 400,
+        body: 'Bad Request',
+      }).as('copyDashboard');
+
+      cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      cy.wait('@copyDashboard');
+
+      cy.get('.pf-v6-c-alert').should('contain.text', 'Failed to duplicate dashboard. Please try again.');
+    });
+
+    it('re-enables form after error', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/1/copy', {
+        statusCode: 500,
+        body: 'Internal Server Error',
+      }).as('copyDashboard');
+
+      cy.mount(<DuplicateModal isOpen={true} onClose={cy.stub()} dashboards={mockDashboards} />);
+
+      cy.get('select[aria-label="Select a dashboard"]').select('1');
+      cy.get('#duplicate-dashboard-name').type('My Duplicate');
+      cy.contains('button', 'Duplicate dashboard').click();
+
+      cy.wait('@copyDashboard');
+
+      // After error, buttons should be re-enabled
+      cy.contains('button', 'Duplicate dashboard').should('not.be.disabled');
+      cy.contains('button', 'Cancel').should('not.be.disabled');
+    });
+  });
+});

--- a/cypress/component/Header.cy.tsx
+++ b/cypress/component/Header.cy.tsx
@@ -4,7 +4,7 @@ import Header from '../../src/Components/DashboardHub/Header/Header';
 describe('DashboardHub Header', () => {
   const mountHeader = () => {
     const onRefetchDashboards = cy.stub().as('onRefetchDashboards');
-    cy.mount(<Header onRefetchDashboards={onRefetchDashboards} />);
+    cy.mount(<Header onRefetchDashboards={onRefetchDashboards} dashboards={[]} />);
   };
 
   it('renders "Dashboard Hub" heading', () => {
@@ -41,11 +41,9 @@ describe('DashboardHub Header', () => {
 
       cy.contains('[role="menuitem"]', 'Import from config string')
         .should('be.visible')
-        .and('not.be.disabled');
 
       cy.contains('[role="menuitem"]', 'Duplicate existing')
         .should('be.visible')
-        .and('be.disabled');
     });
 
     it('clicking "Import from config string" opens the import modal', () => {

--- a/src/Components/DashboardHub/Header/Header.tsx
+++ b/src/Components/DashboardHub/Header/Header.tsx
@@ -4,12 +4,14 @@ import { ImportModal } from '../ImportModal/ImportModal';
 import { CreateModal } from '../../CreateModal/CreateModal';
 import { DuplicateModal } from '../../DuplicateModal/DuplicateModal';
 import { CodeIcon, CopyIcon, ExternalLinkAltIcon, ThIcon } from '@patternfly/react-icons';
+import { DashboardTemplate } from '../../../api/dashboard-templates';
 
 interface CreateDashboardDropdownProps {
   onRefetchDashboards: () => void;
+  dashboards: DashboardTemplate[];
 }
 
-const CreateDashboardDropdown: React.FunctionComponent<CreateDashboardDropdownProps> = ({ onRefetchDashboards }) => {
+const CreateDashboardDropdown: React.FunctionComponent<CreateDashboardDropdownProps> = ({ onRefetchDashboards, dashboards }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -42,7 +44,12 @@ const CreateDashboardDropdown: React.FunctionComponent<CreateDashboardDropdownPr
         </DropdownList>
       </Dropdown>
       <CreateModal isOpen={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)} onSuccess={onRefetchDashboards} />
-      <DuplicateModal isOpen={isDuplicateModalOpen} onClose={() => setIsDuplicateModalOpen(false)} onSuccess={onRefetchDashboards} />
+      <DuplicateModal
+        isOpen={isDuplicateModalOpen}
+        onClose={() => setIsDuplicateModalOpen(false)}
+        onSuccess={onRefetchDashboards}
+        dashboards={dashboards}
+      />
       <ImportModal isOpen={isImportModalOpen} onClose={() => setIsImportModalOpen(false)} onSuccess={onRefetchDashboards} />
     </>
   );
@@ -50,9 +57,10 @@ const CreateDashboardDropdown: React.FunctionComponent<CreateDashboardDropdownPr
 
 interface HeaderProps {
   onRefetchDashboards: () => void;
+  dashboards: DashboardTemplate[];
 }
 
-const Header: React.FunctionComponent<HeaderProps> = ({ onRefetchDashboards }) => {
+const Header: React.FunctionComponent<HeaderProps> = ({ onRefetchDashboards, dashboards }) => {
   return (
     <PageSection hasBodyWrapper={false} className="widg-c-page__main-section--header pf-v6-u-p-lg pf-v6-u-p-r-0-on-sm">
       <Flex className="widg-l-flex--header" direction={{ default: 'column', lg: 'row' }}>
@@ -69,7 +77,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({ onRefetchDashboards }) =
         </FlexItem>
 
         <FlexItem align={{ default: 'alignLeft', lg: 'alignRight' }}>
-          <CreateDashboardDropdown onRefetchDashboards={onRefetchDashboards} />
+          <CreateDashboardDropdown onRefetchDashboards={onRefetchDashboards} dashboards={dashboards} />
         </FlexItem>
       </Flex>
     </PageSection>

--- a/src/Components/DashboardHub/Header/Header.tsx
+++ b/src/Components/DashboardHub/Header/Header.tsx
@@ -2,6 +2,7 @@ import { Content, Dropdown, DropdownItem, DropdownList, Flex, FlexItem, MenuTogg
 import React, { useState } from 'react';
 import { ImportModal } from '../ImportModal/ImportModal';
 import { CreateModal } from '../../CreateModal/CreateModal';
+import { DuplicateModal } from '../../DuplicateModal/DuplicateModal';
 import { CodeIcon, CopyIcon, ExternalLinkAltIcon, ThIcon } from '@patternfly/react-icons';
 
 interface CreateDashboardDropdownProps {
@@ -12,6 +13,7 @@ const CreateDashboardDropdown: React.FunctionComponent<CreateDashboardDropdownPr
   const [isOpen, setIsOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isDuplicateModalOpen, setIsDuplicateModalOpen] = useState(false);
 
   return (
     <>
@@ -34,12 +36,13 @@ const CreateDashboardDropdown: React.FunctionComponent<CreateDashboardDropdownPr
           <DropdownItem key="import" onClick={() => setIsImportModalOpen(true)}>
             <CodeIcon /> Import from config string
           </DropdownItem>
-          <DropdownItem isDisabled key="duplicate">
+          <DropdownItem key="duplicate" onClick={() => setIsDuplicateModalOpen(true)}>
             <CopyIcon /> Duplicate existing
           </DropdownItem>
         </DropdownList>
       </Dropdown>
       <CreateModal isOpen={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)} onSuccess={onRefetchDashboards} />
+      <DuplicateModal isOpen={isDuplicateModalOpen} onClose={() => setIsDuplicateModalOpen(false)} onSuccess={onRefetchDashboards} />
       <ImportModal isOpen={isImportModalOpen} onClose={() => setIsImportModalOpen(false)} onSuccess={onRefetchDashboards} />
     </>
   );

--- a/src/Components/DuplicateModal/DuplicateModal.tsx
+++ b/src/Components/DuplicateModal/DuplicateModal.tsx
@@ -16,15 +16,16 @@ import React, { useEffect } from 'react';
 import { CopyIcon } from '@patternfly/react-icons';
 import { useAddNotification } from '../../state/notificationsAtom';
 import { useDuplicateDashboard } from '../../hooks/useDuplicateDashboard';
-import useGetDashboards from '../../hooks/useGetDashboards';
+import { DashboardTemplate } from '../../api/dashboard-templates';
 
 interface DuplicateModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: () => void;
+  dashboards: DashboardTemplate[];
 }
 
-export const DuplicateModal: React.FunctionComponent<DuplicateModalProps> = ({ isOpen, onClose, onSuccess }) => {
+export const DuplicateModal: React.FunctionComponent<DuplicateModalProps> = ({ isOpen, onClose, onSuccess, dashboards }) => {
   const {
     name,
     setName,
@@ -38,7 +39,6 @@ export const DuplicateModal: React.FunctionComponent<DuplicateModalProps> = ({ i
     duplicateDashboard,
     reset,
   } = useDuplicateDashboard();
-  const { dashboards } = useGetDashboards();
   const addNotification = useAddNotification();
 
   const handleDashboardChange = (_event: React.FormEvent<HTMLSelectElement>, value: string) => {

--- a/src/Components/DuplicateModal/DuplicateModal.tsx
+++ b/src/Components/DuplicateModal/DuplicateModal.tsx
@@ -1,0 +1,133 @@
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from '@patternfly/react-core';
+import React, { useEffect } from 'react';
+import { CopyIcon } from '@patternfly/react-icons';
+import { useAddNotification } from '../../state/notificationsAtom';
+import { useDuplicateDashboard } from '../../hooks/useDuplicateDashboard';
+import useGetDashboards from '../../hooks/useGetDashboards';
+
+interface DuplicateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export const DuplicateModal: React.FunctionComponent<DuplicateModalProps> = ({ isOpen, onClose, onSuccess }) => {
+  const {
+    name,
+    setName,
+    selectedDashboardId,
+    setSelectedDashboardId,
+    setAsHomepage,
+    setSetAsHomepage,
+    isLoading,
+    error,
+    isFormValid,
+    duplicateDashboard,
+    reset,
+  } = useDuplicateDashboard();
+  const { dashboards } = useGetDashboards();
+  const addNotification = useAddNotification();
+
+  const handleDashboardChange = (_event: React.FormEvent<HTMLSelectElement>, value: string) => {
+    setSelectedDashboardId(value ? Number(value) : null);
+  };
+
+  const handleNameChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setName(value);
+  };
+
+  const handleHomepageChange = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+    setSetAsHomepage(checked);
+  };
+
+  const handleSubmit = async () => {
+    const result = await duplicateDashboard();
+    if (result) {
+      addNotification({
+        variant: 'success',
+        title: `Dashboard '${name}' duplicated successfully`,
+      });
+      onSuccess?.();
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+    }
+  }, [isOpen]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      ouiaId="DuplicateDashboardModal"
+      variant="small"
+      aria-labelledby="duplicate-modal-title"
+      aria-describedby="modal-box-body-duplicate"
+    >
+      <ModalHeader title="Duplicate existing dashboard" titleIconVariant={CopyIcon} labelId="duplicate-modal-title" />
+      <ModalBody id="modal-box-body-duplicate">
+        {error && (
+          <Alert variant="danger" title="Duplication failed" isInline className="pf-v6-u-mb-md">
+            {error}
+          </Alert>
+        )}
+        <Form>
+          <FormGroup label="Select existing dashboard for duplication" isRequired>
+            <FormSelect value={selectedDashboardId ?? ''} onChange={handleDashboardChange} aria-label="Select a dashboard">
+              <FormSelectOption value="" label="Select a dashboard" isPlaceholder />
+              {dashboards.map((dashboard) => (
+                <FormSelectOption key={dashboard.id} value={dashboard.id} label={dashboard.dashboardName} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+          <FormGroup label="New dashboard name" isRequired>
+            <TextInput
+              value={name}
+              isRequired
+              validated={isFormValid ? 'success' : 'default'}
+              type="text"
+              id="duplicate-dashboard-name"
+              name="duplicate-dashboard-name"
+              placeholder="duplicate dashboard"
+              onChange={handleNameChange}
+            />
+          </FormGroup>
+          <FormGroup>
+            <Checkbox label="Set as homepage" id="set-as-homepage" isChecked={setAsHomepage} onChange={handleHomepageChange} />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key="confirm"
+          variant="primary"
+          onClick={handleSubmit}
+          isDisabled={!isFormValid || isLoading}
+          isLoading={isLoading}
+          spinnerAriaLabel="Duplicating dashboard"
+        >
+          {isLoading ? 'Duplicating...' : 'Duplicate dashboard'}
+        </Button>
+        <Button key="cancel" variant="link" onClick={onClose} isDisabled={isLoading}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/src/Modules/DashboardHub.tsx
+++ b/src/Modules/DashboardHub.tsx
@@ -21,7 +21,7 @@ const DashboardHub = () => {
         element={
           <div className="dashboardHub">
             <Portal notifications={notifications} removeNotification={removeNotification} />
-            <Header onRefetchDashboards={fetchDashboards} />
+            <Header onRefetchDashboards={fetchDashboards} dashboards={dashboards} />
             <PageSection>
               <DashboardTable dashboards={dashboards} onRefetchDashboards={fetchDashboards} />
             </PageSection>

--- a/src/api/dashboard-templates.ts
+++ b/src/api/dashboard-templates.ts
@@ -268,6 +268,17 @@ export const exportDashboardTemplate = async (templateId: number): Promise<Expor
   return json;
 };
 
+export const copyDashboardTemplate = async (templateId: DashboardTemplate['id'], data: { dashboardName: string }): Promise<DashboardTemplate> => {
+  const resp = await fetch(`/api/widget-layout/v1/${templateId}/copy`, {
+    method: 'POST',
+    headers: getRequestHeaders(),
+    body: JSON.stringify(data),
+  });
+  handleErrors(resp);
+  const json = await resp.json();
+  return json;
+};
+
 export const getDefaultTemplate = (templates: DashboardTemplate[]): DashboardTemplate | undefined => {
   return templates.find((itm) => itm.default === true);
 };

--- a/src/hooks/tests/useDuplicateDashboard.test.ts
+++ b/src/hooks/tests/useDuplicateDashboard.test.ts
@@ -1,0 +1,289 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDuplicateDashboard } from '../useDuplicateDashboard';
+import { DashboardTemplate, DashboardTemplatesError, copyDashboardTemplate, setDefaultTemplate } from '../../api/dashboard-templates';
+
+jest.mock('../../api/dashboard-templates', () => ({
+  ...jest.requireActual('../../api/dashboard-templates'),
+  copyDashboardTemplate: jest.fn(),
+  setDefaultTemplate: jest.fn(),
+}));
+
+const mockedCopyDashboardTemplate = copyDashboardTemplate as jest.MockedFunction<typeof copyDashboardTemplate>;
+const mockedSetDefaultTemplate = setDefaultTemplate as jest.MockedFunction<typeof setDefaultTemplate>;
+
+const mockDashboard: DashboardTemplate = {
+  id: 42,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  deletedAt: null,
+  userIdentityID: 1,
+  default: false,
+  templateBase: { name: 'test', displayName: 'Test' },
+  templateConfig: { sm: [], md: [], lg: [], xl: [] },
+  dashboardName: 'Test Dashboard',
+};
+
+describe('useDuplicateDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return initial state with isLoading false, error null, and isFormValid false', () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    expect(result.current.name).toBe('');
+    expect(result.current.selectedDashboardId).toBeNull();
+    expect(result.current.setAsHomepage).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isFormValid).toBe(false);
+    expect(typeof result.current.setName).toBe('function');
+    expect(typeof result.current.setSelectedDashboardId).toBe('function');
+    expect(typeof result.current.setSetAsHomepage).toBe('function');
+    expect(typeof result.current.duplicateDashboard).toBe('function');
+    expect(typeof result.current.reset).toBe('function');
+  });
+
+  it('should update name when setName is called', () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    act(() => {
+      result.current.setName('My Dashboard');
+    });
+
+    expect(result.current.name).toBe('My Dashboard');
+  });
+
+  it('should update selectedDashboardId when setSelectedDashboardId is called', () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    act(() => {
+      result.current.setSelectedDashboardId(5);
+    });
+
+    expect(result.current.selectedDashboardId).toBe(5);
+  });
+
+  it('should update setAsHomepage when setSetAsHomepage is called', () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    act(() => {
+      result.current.setSetAsHomepage(true);
+    });
+
+    expect(result.current.setAsHomepage).toBe(true);
+  });
+
+  it('should set isFormValid to true when name is non-empty and selectedDashboardId is not null', () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    act(() => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    expect(result.current.isFormValid).toBe(true);
+  });
+
+  it('should set isFormValid to false when name is whitespace only', () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    act(() => {
+      result.current.setName('   ');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    expect(result.current.isFormValid).toBe(false);
+  });
+
+  it('should return null and not call API when form is invalid', async () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    let duplicateResult: DashboardTemplate | null = mockDashboard;
+    await act(async () => {
+      duplicateResult = await result.current.duplicateDashboard();
+    });
+
+    expect(duplicateResult).toBeNull();
+    expect(mockedCopyDashboardTemplate).not.toHaveBeenCalled();
+    expect(mockedSetDefaultTemplate).not.toHaveBeenCalled();
+  });
+
+  it('should call copyDashboardTemplate with correct args and return the new dashboard', async () => {
+    mockedCopyDashboardTemplate.mockResolvedValue(mockDashboard);
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    let duplicateResult: DashboardTemplate | null = null;
+    await act(async () => {
+      duplicateResult = await result.current.duplicateDashboard();
+    });
+
+    expect(duplicateResult).toEqual(mockDashboard);
+    expect(mockedCopyDashboardTemplate).toHaveBeenCalledWith(1, { dashboardName: 'My Copy' });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should call setDefaultTemplate when setAsHomepage is true', async () => {
+    mockedCopyDashboardTemplate.mockResolvedValue(mockDashboard);
+    mockedSetDefaultTemplate.mockResolvedValue(mockDashboard);
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+      result.current.setSetAsHomepage(true);
+    });
+
+    await act(async () => {
+      await result.current.duplicateDashboard();
+    });
+
+    expect(mockedSetDefaultTemplate).toHaveBeenCalledWith(42);
+  });
+
+  it('should not call setDefaultTemplate when setAsHomepage is false', async () => {
+    mockedCopyDashboardTemplate.mockResolvedValue(mockDashboard);
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    await act(async () => {
+      await result.current.duplicateDashboard();
+    });
+
+    expect(mockedSetDefaultTemplate).not.toHaveBeenCalled();
+  });
+
+  it('should set server error message when DashboardTemplatesError has status >= 500', async () => {
+    mockedCopyDashboardTemplate.mockRejectedValue(new DashboardTemplatesError('Server error', 500, {} as Response));
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    let duplicateResult: DashboardTemplate | null = mockDashboard;
+    await act(async () => {
+      duplicateResult = await result.current.duplicateDashboard();
+    });
+
+    expect(duplicateResult).toBeNull();
+    expect(result.current.error).toBe('The server is currently unavailable. Please try again later.');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should set generic failed message when DashboardTemplatesError has status < 500', async () => {
+    mockedCopyDashboardTemplate.mockRejectedValue(new DashboardTemplatesError('Bad request', 400, {} as Response));
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    let duplicateResult: DashboardTemplate | null = mockDashboard;
+    await act(async () => {
+      duplicateResult = await result.current.duplicateDashboard();
+    });
+
+    expect(duplicateResult).toBeNull();
+    expect(result.current.error).toBe('Failed to duplicate dashboard. Please try again.');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should set network error message when TypeError is thrown', async () => {
+    mockedCopyDashboardTemplate.mockRejectedValue(new TypeError('Failed to fetch'));
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    let duplicateResult: DashboardTemplate | null = mockDashboard;
+    await act(async () => {
+      duplicateResult = await result.current.duplicateDashboard();
+    });
+
+    expect(duplicateResult).toBeNull();
+    expect(result.current.error).toBe('Network error. Please check your connection and try again.');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should set unexpected error message when unknown error is thrown', async () => {
+    mockedCopyDashboardTemplate.mockRejectedValue('something went wrong');
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    let duplicateResult: DashboardTemplate | null = mockDashboard;
+    await act(async () => {
+      duplicateResult = await result.current.duplicateDashboard();
+    });
+
+    expect(duplicateResult).toBeNull();
+    expect(result.current.error).toBe('An unexpected error occurred. Please try again.');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should restore initial state when reset is called', async () => {
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+      result.current.setSetAsHomepage(true);
+    });
+
+    expect(result.current.name).toBe('My Copy');
+    expect(result.current.selectedDashboardId).toBe(1);
+    expect(result.current.setAsHomepage).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.name).toBe('');
+    expect(result.current.selectedDashboardId).toBeNull();
+    expect(result.current.setAsHomepage).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should clear previous error on a new successful call', async () => {
+    mockedCopyDashboardTemplate.mockRejectedValueOnce(new DashboardTemplatesError('Bad request', 400, {} as Response));
+    mockedCopyDashboardTemplate.mockResolvedValueOnce(mockDashboard);
+    const { result } = renderHook(() => useDuplicateDashboard());
+
+    await act(async () => {
+      result.current.setName('My Copy');
+      result.current.setSelectedDashboardId(1);
+    });
+
+    await act(async () => {
+      await result.current.duplicateDashboard();
+    });
+
+    expect(result.current.error).toBe('Failed to duplicate dashboard. Please try again.');
+
+    await act(async () => {
+      await result.current.duplicateDashboard();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/hooks/useDuplicateDashboard.ts
+++ b/src/hooks/useDuplicateDashboard.ts
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { DashboardTemplate, DashboardTemplatesError, copyDashboardTemplate, setDefaultTemplate } from '../api/dashboard-templates';
+
+interface DuplicateDashboardState {
+  name: string;
+  selectedDashboardId: number | null;
+  setAsHomepage: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const initState: DuplicateDashboardState = {
+  name: '',
+  selectedDashboardId: null,
+  setAsHomepage: false,
+  isLoading: false,
+  error: null,
+};
+
+type UseDuplicateDashboardReturn = DuplicateDashboardState & {
+  setName: (value: string) => void;
+  setSelectedDashboardId: (value: number | null) => void;
+  setSetAsHomepage: (value: boolean) => void;
+  isFormValid: boolean;
+  duplicateDashboard: () => Promise<DashboardTemplate | null>;
+  reset: () => void;
+};
+
+export const useDuplicateDashboard = (): UseDuplicateDashboardReturn => {
+  const [state, setState] = useState<DuplicateDashboardState>(initState);
+
+  const isFormValid = state.name.trim() !== '' && state.selectedDashboardId !== null;
+
+  const reset = () => setState(initState);
+
+  const setName = (value: string) => setState((prev) => ({ ...prev, name: value }));
+
+  const setSelectedDashboardId = (value: number | null) => setState((prev) => ({ ...prev, selectedDashboardId: value }));
+
+  const setSetAsHomepage = (value: boolean) => setState((prev) => ({ ...prev, setAsHomepage: value }));
+
+  const duplicateDashboard = async (): Promise<DashboardTemplate | null> => {
+    if (!isFormValid || state.selectedDashboardId === null) {
+      return null;
+    }
+
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const newDashboard = await copyDashboardTemplate(state.selectedDashboardId, { dashboardName: state.name });
+
+      if (state.setAsHomepage) {
+        await setDefaultTemplate(newDashboard.id);
+      }
+
+      setState((prev) => ({ ...prev, isLoading: false }));
+      return newDashboard;
+    } catch (err) {
+      let errorMessage: string;
+      if (err instanceof DashboardTemplatesError && err.status >= 500) {
+        errorMessage = 'The server is currently unavailable. Please try again later.';
+      } else if (err instanceof DashboardTemplatesError) {
+        errorMessage = 'Failed to duplicate dashboard. Please try again.';
+      } else if (err instanceof TypeError) {
+        errorMessage = 'Network error. Please check your connection and try again.';
+      } else {
+        errorMessage = 'An unexpected error occurred. Please try again.';
+      }
+      setState((prev) => ({ ...prev, error: errorMessage, isLoading: false }));
+      return null;
+    }
+  };
+
+  return {
+    ...state,
+    setName,
+    setSelectedDashboardId,
+    setSetAsHomepage,
+    isFormValid,
+    duplicateDashboard,
+    reset,
+  };
+};
+
+export default useDuplicateDashboard;


### PR DESCRIPTION
### Description
## Summary                                                                                                                                                                                                      
  - Add duplicate dashboard functionality via a new `DuplicateModal` component with dashboard selection, naming, and "set as homepage" option. `DuplicateModal` receives `dashboards` as a prop                                                                   
  - Add `useDuplicateDashboard` hook using the `copyDashboardTemplate` API endpoint (`POST /api/widget-layout/v1/{id}/copy`)                                                                                      
  - Add unit tests for the hook and Cypress component tests for the modal                                                                                                                                                                                                                     
                                                                                                                                                                                                                 

[RHCLOUD-46113](https://redhat.atlassian.net/browse/RHCLOUD-46113)

---

### Screenshots



<img width="309" height="205" alt="Screenshot 2026-04-07 at 14 52 23" src="https://github.com/user-attachments/assets/b4f95c85-89e3-4fe2-9ad9-9136b89170ab" /> Duplicate dashboard on Dashboard Hub page

<img width="605" height="389" alt="Screenshot 2026-04-07 at 14 52 38" src="https://github.com/user-attachments/assets/f294f9cc-7e4f-4d3c-a9d7-d05ed16af9bc" /> Duplicate dashboard modal. Disabled button  

<img width="598" height="434" alt="Screenshot 2026-04-07 at 14 53 00" src="https://github.com/user-attachments/assets/64cdf623-af2e-47f9-8ab2-6faa5ee05d85" /> List of dashboards that can be duplicated

<img width="594" height="379" alt="Screenshot 2026-04-07 at 14 53 20" src="https://github.com/user-attachments/assets/717e41de-0fc6-4db3-8cf2-f51a56ab41ee" /> Duplicate dashboard modal. Ready to submit

<img width="1724" height="712" alt="Screenshot 2026-04-07 at 14 53 26" src="https://github.com/user-attachments/assets/61f0cd0b-dfa0-4f46-9996-d2eca28aaeac" />
Sucesessful alert after duplication

[RHCLOUD-46113]: https://redhat.atlassian.net/browse/RHCLOUD-46113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ