### PR TITLE
Set as homepage

### DIFF
--- a/cypress/component/DashboardTable.cy.tsx
+++ b/cypress/component/DashboardTable.cy.tsx
@@ -162,6 +162,76 @@ describe('DashboardTable', () => {
     cy.get('[role="menuitem"]').contains('Delete dashboard').should('exist');
   });
 
+  describe('Set as homepage', () => {
+    it('shows home icon for the default dashboard', () => {
+      cy.mount(
+        <MemoryRouter>
+          <FlagProvider unleashClient={createMockClient(false)} startClient={false}>
+            <DashboardTable dashboards={mockDashboards} onRefetchDashboards={cy.stub()} />
+          </FlagProvider>
+        </MemoryRouter>
+      );
+
+      // Charlie Dashboard is default, sorted to index 2 (ascending by name: Alpha, Bravo, Charlie)
+      cy.get('tbody tr').eq(2).find('td').eq(0).find('svg').should('exist');
+      // Non-default dashboards should not have the icon
+      cy.get('tbody tr').eq(0).find('td').eq(0).find('svg').should('not.exist');
+      cy.get('tbody tr').eq(1).find('td').eq(0).find('svg').should('not.exist');
+    });
+
+    it('"Set as homepage" is disabled for the default dashboard', () => {
+      cy.mount(
+        <MemoryRouter>
+          <FlagProvider unleashClient={createMockClient(false)} startClient={false}>
+            <DashboardTable dashboards={mockDashboards} onRefetchDashboards={cy.stub()} />
+          </FlagProvider>
+        </MemoryRouter>
+      );
+
+      // Charlie Dashboard (index 2) is default
+      cy.get('tbody tr').eq(2).find('button[aria-label="Kebab toggle"]').click();
+      cy.get('[role="menuitem"]').contains('Set as homepage').closest('button').should('have.attr', 'aria-disabled', 'true');
+    });
+
+    it('"Set as homepage" is enabled for non-default dashboards', () => {
+      cy.mount(
+        <MemoryRouter>
+          <FlagProvider unleashClient={createMockClient(false)} startClient={false}>
+            <DashboardTable dashboards={mockDashboards} onRefetchDashboards={cy.stub()} />
+          </FlagProvider>
+        </MemoryRouter>
+      );
+
+      // Alpha Dashboard (index 0) is not default
+      cy.get('tbody tr').eq(0).find('button[aria-label="Kebab toggle"]').click();
+      cy.get('[role="menuitem"]').contains('Set as homepage').closest('button').should('not.have.attr', 'aria-disabled', 'true');
+    });
+
+    it('calls API and refetches when "Set as homepage" is clicked', () => {
+      cy.intercept('POST', '/api/widget-layout/v1/*/default', {
+        statusCode: 200,
+        body: {},
+      }).as('setDefault');
+
+      const refetchStub = cy.stub().as('refetch');
+
+      cy.mount(
+        <MemoryRouter>
+          <FlagProvider unleashClient={createMockClient(false)} startClient={false}>
+            <DashboardTable dashboards={mockDashboards} onRefetchDashboards={refetchStub} />
+          </FlagProvider>
+        </MemoryRouter>
+      );
+
+      // Click "Set as homepage" on Alpha Dashboard (index 0, non-default)
+      cy.get('tbody tr').eq(0).find('button[aria-label="Kebab toggle"]').click();
+      cy.get('[role="menuitem"]').contains('Set as homepage').click();
+
+      cy.wait('@setDefault');
+      cy.get('@refetch').should('have.been.calledOnce');
+    });
+  });
+
   describe('Delete dashboard', () => {
     it('"Delete dashboard" is hidden when feature flag is off', () => {
       cy.mount(

--- a/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
+++ b/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 import { ActionsColumn } from '@patternfly/react-table';
-import { Button } from '@patternfly/react-core';
+import { Button, Content, TooltipPosition } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { DashboardTemplate } from '../../../api/dashboard-templates';
+import { DashboardTemplate, setDefaultTemplate } from '../../../api/dashboard-templates';
 import { CodeIcon, CopyIcon, EditAltIcon, HomeIcon, TrashIcon, UsersIcon } from '@patternfly/react-icons';
 import { useExportDashboard } from '../../../hooks/useExportDashboard';
 import { useDeleteDashboard } from '../../../hooks/useDeleteDashboard';
@@ -17,6 +17,7 @@ interface Dashboard {
   name: string;
   description: string; // TODO
   lastModified: string;
+  isDefault: boolean;
 }
 
 interface DashboardTableProps {
@@ -42,6 +43,7 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
     name: dashboard.dashboardName,
     description: dashboard.templateBase.name, // TODO: Update when description field is available
     lastModified: dashboard.updatedAt,
+    isDefault: dashboard.default,
   }));
 
   const columnNames = {
@@ -66,6 +68,11 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
         console.error('Failed to copy to clipboard:', err);
       }
     }
+  };
+
+  const handleSetAsHomepage = async (dashboardId: number) => {
+    await setDefaultTemplate(dashboardId);
+    onRefetchDashboards();
   };
 
   // Sort dashboards by name
@@ -99,8 +106,9 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
     {
       icon: <HomeIcon />,
       title: 'Set as homepage',
-      isDisabled: true,
-      onClick: () => console.log(`Set as homepage dashboard ${dashboard.id}`),
+      isAriaDisabled: dashboard.isDefault,
+      tooltipProps: dashboard.isDefault ? { content: 'This dashboard is already set to your homepage', position: TooltipPosition.left } : undefined,
+      onClick: () => handleSetAsHomepage(dashboard.id),
     },
     {
       icon: <CodeIcon />,
@@ -151,6 +159,7 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
       <Table aria-label="Dashboards table" ouiaId="DashboardsTable">
         <Thead>
           <Tr>
+            <Th screenReaderText="Homepage" modifier="fitContent" />
             <Th sort={getSortParams()}>{columnNames.name}</Th>
             <Th>{columnNames.description}</Th>
             <Th>{columnNames.lastModified}</Th>
@@ -160,6 +169,7 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
         <Tbody>
           {sortedDashboards.map((dashboard) => (
             <Tr key={dashboard.id}>
+              <Td>{dashboard.isDefault && <HomeIcon />}</Td>
               <Td dataLabel={columnNames.name}>
                 <Link to={`/staging/dashboard-hub/${dashboard.id}`}>{dashboard.name}</Link>
               </Td>


### PR DESCRIPTION
### Description

- Enabled the "Set as homepage" action in the dashboard kebab menu                                                                                                                                                           
- Added a new first column to the table that displays a home icon for the default dashboard
- The action is aria-disabled with a tooltip when the dashboard is already set as homepage                                                                                                                                   
- Refetches dashboards after setting a new homepage                                                                                                                                                                          
- Added 4 Cypress tests covering: home icon display, disabled/enabled state, API call and refetch  


[RHCLOUD46631](https://redhat.atlassian.net/browse/RHCLOUD-46631)

---

### Screenshots
<img width="1401" height="586" alt="Screenshot 2026-04-13 at 9 58 33" src="https://github.com/user-attachments/assets/d9a4d1fe-2a0e-46d2-a976-2526ebb1c0fe" />
Enabled option "Set as homepage" in kebab dropdown
<img width="1415" height="510" alt="Screenshot 2026-04-13 at 9 59 16" src="https://github.com/user-attachments/assets/ff067175-2f7d-4660-984f-9abaf2d5848b" />
Dashboard is set as default after clicking 
<img width="1399" height="492" alt="Screenshot 2026-04-13 at 9 59 37" src="https://github.com/user-attachments/assets/f1d3d6f9-4aa9-4607-8cdf-e140c0bc09f5" />
Disabled option for already default dashboard
