### PR TITLE
chore: wire Dashboard Hub to /dashboard-hub

### DIFF
--- a/cypress/component/KebabDropdown.cy.tsx
+++ b/cypress/component/KebabDropdown.cy.tsx
@@ -50,7 +50,7 @@ describe('KebabDropdown', () => {
 
     cy.contains('[role="menuitem"]', 'Dashboard Hub')
       .should('not.be.disabled')
-      .should('have.attr', 'href', '/staging/dashboard-hub');
+      .should('have.attr', 'href', '/dashboard-hub');
   });
 
   it('toggle button has expanded state when open', () => {
@@ -62,7 +62,7 @@ describe('KebabDropdown', () => {
   it('renders dashboard items with correct links', () => {
     cy.get('button[aria-label="kebab dropdown toggle"]').click();
 
-    cy.contains('[role="menuitem"]', 'My Dashboard').should('have.attr', 'href', '/staging/dashboard-hub/1');
+    cy.contains('[role="menuitem"]', 'My Dashboard').should('have.attr', 'href', '/dashboard-hub/1');
   });
 
   it('drills into Create new dashboard submenu and displays options', () => {

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -31,7 +31,7 @@ objects:
           - id: dashboardHub
             module: ./DashboardHub
             routes:
-            - pathname: /staging/dashboard-hub
+            - pathname: /dashboard-hub
 
 parameters:
   - name: ENV_NAME

--- a/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
+++ b/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
@@ -171,7 +171,7 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
             <Tr key={dashboard.id}>
               <Td>{dashboard.isDefault && <HomeIcon />}</Td>
               <Td dataLabel={columnNames.name}>
-                <Link to={`/staging/dashboard-hub/${dashboard.id}`}>{dashboard.name}</Link>
+                <Link to={`/dashboard-hub/${dashboard.id}`}>{dashboard.name}</Link>
               </Td>
               <Td dataLabel={columnNames.description}>{dashboard.description}</Td>
               <Td dataLabel={columnNames.lastModified}>

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -119,7 +119,7 @@ export const KebabDropdown = ({ dashboards }: { dashboards: DashboardTemplate[] 
                       isDisabled
                     />
                   }
-                  component={(props) => <Link {...props} to={`/staging/dashboard-hub/${dashboard.id}`} />}
+                  component={(props) => <Link {...props} to={`/dashboard-hub/${dashboard.id}`} />}
                 >
                   {dashboard.dashboardName}
                 </MenuItem>
@@ -152,7 +152,7 @@ export const KebabDropdown = ({ dashboards }: { dashboards: DashboardTemplate[] 
             Create new dashboard
           </MenuItem>
           <Divider component="li" key="separator" />
-          <MenuItem component={(props) => <Link {...props} to="/staging/dashboard-hub" />} description="Create, manage, share dashboards">
+          <MenuItem component={(props) => <Link {...props} to="/dashboard-hub" />} description="Create, manage, share dashboards">
             Dashboard Hub
           </MenuItem>
         </MenuList>


### PR DESCRIPTION
### Description
 - Change Dashboard Hub route from /staging/dashboard-hub to /dashboard-hub
  - Update all internal navigation links to use the new path 

[RHCLOUD46795](https://redhat.atlassian.net/browse/RHCLOUD-46795)
