### PR TITLE
fix: change dashboard type to 'custom' when creating from blank

### DIFF
--- a/src/hooks/tests/useCreateBlankDashboard.test.ts
+++ b/src/hooks/tests/useCreateBlankDashboard.test.ts
@@ -19,7 +19,7 @@ const mockDashboardTemplate = {
   deletedAt: null,
   userIdentityID: 1,
   default: false,
-  templateBase: { name: 'landingPage', displayName: 'Landing Page' },
+  templateBase: { name: 'custom', displayName: 'Custom' },
   templateConfig: { sm: [], md: [], lg: [], xl: [] },
   dashboardName: 'My Dashboard',
 };
@@ -120,7 +120,7 @@ describe('useCreateBlankDashboard', () => {
 
     expect(mockedImportDashboardTemplate).toHaveBeenCalledWith({
       dashboardName: 'My Dashboard',
-      templateBase: { name: 'landingPage', displayName: 'Landing Page' },
+      templateBase: { name: 'custom', displayName: 'Custom' },
       templateConfig: { sm: [], md: [], lg: [], xl: [] },
     });
     expect(createResult).toEqual(mockDashboardTemplate);

--- a/src/hooks/useCreateBlankDashboard.ts
+++ b/src/hooks/useCreateBlankDashboard.ts
@@ -55,8 +55,8 @@ export const useCreateBlankDashboard = (): UseCreateBlankDashboardReturn => {
       const result = await create({
         dashboardName: state.name,
         templateBase: {
-          name: 'landingPage',
-          displayName: 'Landing Page',
+          name: 'custom',
+          displayName: 'Custom',
         },
         templateConfig: blankTemplateConfig,
         setAsHomepage: state.setAsHomepage,


### PR DESCRIPTION
### Description

Fixed an issue where creating a dashboard from a blank state incorrectly assigned the landingPage template type.

#### Changes

Updated `useCreateBlankDashboard` to set templateBase properties to `custom`.

---