### PR TITLE
fix: update default dashboard on landing page when changed from hub

### DIFF
--- a/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
+++ b/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 import { ActionsColumn } from '@patternfly/react-table';
-import { Button, Content, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Alert, Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { DashboardTemplate } from '../../../api/dashboard-templates';
 import { setDefaultDashboardAtom } from '../../../state/dashboardsAtom';
@@ -154,6 +154,8 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
       : []),
   ];
 
+  const hasHomepage = dashboards.length === 0 || dashboards.some((d) => d.default);
+
   const handleDeleteConfirm = async () => {
     if (dashboardToDelete) {
       const name = dashboardToDelete.name;
@@ -180,6 +182,7 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
         onClose={() => setDashboardToDelete(null)}
         onDelete={handleDeleteConfirm}
       />
+      {!hasHomepage && <Alert variant="warning" isInline title="No homepage dashboard set. Please set a dashboard as your homepage." />}
       <Table aria-label="Dashboards table" ouiaId="DashboardsTable">
         <Thead>
           <Tr>

--- a/src/hooks/useDashboardTemplate.ts
+++ b/src/hooks/useDashboardTemplate.ts
@@ -12,6 +12,7 @@ import {
 import { useApi } from './useApi';
 import { useSetAtom } from 'jotai';
 import { renameDashboardAtom } from '../state/dashboardsAtom';
+import { templateIdAtom } from '../state/templateAtom';
 
 const remapWidgetTypes = (extendedTemplate: ExtendedTemplateConfig, widgetMapping: WidgetMapping): ExtendedTemplateConfig => {
   // Build reverse lookup: "landing-./RhelWidget" -> "rhel"
@@ -47,6 +48,7 @@ const useDashboardTemplate = (id: number) => {
   const api = useApi();
   const debouncedPatchDashboardTemplate = useMemo(() => DebouncePromise(api.patchDashboardTemplateHub, 1500, { onlyResolvesLast: true }), [api]);
   const renameDashboardInList = useSetAtom(renameDashboardAtom);
+  const invalidateStartPage = useSetAtom(templateIdAtom);
 
   useEffect(() => {
     const fetchTemplate = async () => {
@@ -98,11 +100,14 @@ const useDashboardTemplate = (id: number) => {
         });
 
         await debouncedPatchDashboardTemplate(id, { templateConfig });
+        if (dashboard?.default) {
+          invalidateStartPage(-1);
+        }
       } catch (err) {
         console.error(err);
       }
     },
-    [id]
+    [id, dashboard?.default]
   );
 
   return { template, saveTemplate, renameDashboard, isLoaded, dashboard, error };

--- a/src/state/dashboardsAtom.ts
+++ b/src/state/dashboardsAtom.ts
@@ -1,14 +1,18 @@
 import { atom } from 'jotai';
 import { DashboardTemplate, TemplateConfig } from '../api/dashboard-templates';
 import { getApi } from './store';
+import { templateIdAtom } from './templateAtom';
 
 export const dashboardsAtom = atom<DashboardTemplate[]>([]);
 
-export const deleteDashboardAtom = atom(null, async (_get, set, id: DashboardTemplate['id']) => {
+export const deleteDashboardAtom = atom(null, async (get, set, id: DashboardTemplate['id']) => {
   const api = getApi();
   await api.deleteDashboardTemplateFromHub(id);
   const dashboards = await api.getUsersDashboards();
   set(dashboardsAtom, dashboards);
+  if (get(templateIdAtom) === id) {
+    set(templateIdAtom, -1);
+  }
 });
 
 export const renameDashboardAtom = atom(null, async (_get, set, { id, dashboardName }: { id: DashboardTemplate['id']; dashboardName: string }) => {
@@ -24,6 +28,7 @@ export const setDefaultDashboardAtom = atom(null, async (_get, set, id: Dashboar
   await api.setDefaultTemplate(id);
   const dashboards = await api.getUsersDashboards();
   set(dashboardsAtom, dashboards);
+  set(templateIdAtom, -1);
 });
 
 export const createDashboardAtom = atom(
@@ -38,6 +43,7 @@ export const createDashboardAtom = atom(
     const result = await api.importDashboardTemplate(importData);
     if (setAsHomepage) {
       await api.setDefaultTemplate(result.id);
+      set(templateIdAtom, -1);
     }
     const dashboards = await api.getUsersDashboards();
     set(dashboardsAtom, dashboards);
@@ -63,6 +69,7 @@ export const duplicateDashboardAtom = atom(
     const result = await api.copyDashboardTemplate(data.id, { dashboardName: data.dashboardName });
     if (data.setAsHomepage) {
       await api.setDefaultTemplate(result.id);
+      set(templateIdAtom, -1);
     }
     const dashboards = await api.getUsersDashboards();
     set(dashboardsAtom, dashboards);

--- a/src/state/tests/dashboardsAtom.test.ts
+++ b/src/state/tests/dashboardsAtom.test.ts
@@ -1,0 +1,81 @@
+import { createStore } from 'jotai';
+import { dashboardsAtom, deleteDashboardAtom } from '../dashboardsAtom';
+import { templateIdAtom } from '../templateAtom';
+import { DashboardTemplate } from '../../api/dashboard-templates';
+
+const mockDeleteDashboardTemplateFromHub = jest.fn();
+const mockGetUsersDashboards = jest.fn();
+
+jest.mock('../store', () => ({
+  getApi: () => ({
+    deleteDashboardTemplateFromHub: mockDeleteDashboardTemplateFromHub,
+    getUsersDashboards: mockGetUsersDashboards,
+  }),
+}));
+
+const makeDashboard = (overrides: Partial<DashboardTemplate> = {}): DashboardTemplate => ({
+  id: 1,
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  deletedAt: null,
+  userId: 'user-1',
+  default: false,
+  templateBase: { name: 'base', displayName: 'Base' },
+  templateConfig: { sm: [], md: [], lg: [], xl: [] },
+  dashboardName: 'Dashboard 1',
+  ...overrides,
+});
+
+describe('deleteDashboardAtom', () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = createStore();
+  });
+
+  it('should call the API to delete the dashboard and refresh the list', async () => {
+    const remaining = [makeDashboard({ id: 2, dashboardName: 'Dashboard 2' })];
+    mockDeleteDashboardTemplateFromHub.mockResolvedValue(true);
+    mockGetUsersDashboards.mockResolvedValue(remaining);
+
+    store.set(dashboardsAtom, [makeDashboard({ id: 1 }), ...remaining]);
+
+    await store.set(deleteDashboardAtom, 1);
+
+    expect(mockDeleteDashboardTemplateFromHub).toHaveBeenCalledWith(1);
+    expect(mockGetUsersDashboards).toHaveBeenCalled();
+    expect(store.get(dashboardsAtom)).toEqual(remaining);
+  });
+
+  it('should reset templateIdAtom when the deleted dashboard is currently selected', async () => {
+    mockDeleteDashboardTemplateFromHub.mockResolvedValue(true);
+    mockGetUsersDashboards.mockResolvedValue([]);
+
+    store.set(templateIdAtom, 5);
+    store.set(dashboardsAtom, [makeDashboard({ id: 5 })]);
+
+    await store.set(deleteDashboardAtom, 5);
+
+    expect(store.get(templateIdAtom)).toBe(-1);
+  });
+
+  it('should not reset templateIdAtom when a different dashboard is deleted', async () => {
+    mockDeleteDashboardTemplateFromHub.mockResolvedValue(true);
+    mockGetUsersDashboards.mockResolvedValue([makeDashboard({ id: 3 })]);
+
+    store.set(templateIdAtom, 3);
+    store.set(dashboardsAtom, [makeDashboard({ id: 3 }), makeDashboard({ id: 7 })]);
+
+    await store.set(deleteDashboardAtom, 7);
+
+    expect(store.get(templateIdAtom)).toBe(3);
+  });
+
+  it('should propagate API errors', async () => {
+    mockDeleteDashboardTemplateFromHub.mockRejectedValue(new Error('Network error'));
+
+    await expect(store.set(deleteDashboardAtom, 1)).rejects.toThrow('Network error');
+    expect(mockGetUsersDashboards).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION


### Description

Fixes stale dashboard data on the start page when navigating from the Dashboard Hub or generic dashboard pages. Previously, the start page cached the homepage dashboard in jotai atoms and never re-fetched, even after the user changed their homepage or edited the homepage dashboard's layout on another page.

  **Changes:**
  - **`dashboardsAtom.ts`**: Invalidates `templateIdAtom` (resets to -1) when setting a new homepage (`setDefaultDashboardAtom`), creating/duplicating with "set as homepage" enabled, or deleting the current
  homepage dashboard.
  - **`useDashboardTemplate.ts`**: Invalidates `templateIdAtom` after saving template changes on the generic dashboard page, but only if the edited dashboard is the homepage (`dashboard.default`).
  Invalidation runs after the debounced API call completes to avoid a race condition where the start page re-fetches before the patch lands.
  - **`DashboardTable.tsx`**: Shows an inline warning alert when no dashboard is set as homepage (e.g., after deleting the homepage dashboard).

  **How it works:** The start page (`useDashboardConfig`) only fetches when `templateIdAtom < 0`. Mutations that affect the homepage reset it to -1, so the next time the start page mounts, it fetches fresh data from the API.

[RHCLOUD48080](https://redhat.atlassian.net/browse/RHCLOUD-48080)

---

### Screenshots
<img width="1695" height="514" alt="Screenshot 2026-06-01 at 12 23 35" src="https://github.com/user-attachments/assets/1cbe6cc5-ae75-40f5-a307-247de196459b" />
