### PR TITLE
feat: add breadcrumb navigation to generic dashboard page

### DIFF
--- a/cypress/component/Header.cy.tsx
+++ b/cypress/component/Header.cy.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import Header from '../../src/Components/DashboardHub/Header/Header';
 
 describe('DashboardHub Header', () => {
   const mountHeader = () => {
     const onRefetchDashboards = cy.stub().as('onRefetchDashboards');
-    cy.mount(<Header onRefetchDashboards={onRefetchDashboards} dashboards={[]} />);
+    cy.mount(
+      <MemoryRouter>
+        <Header onRefetchDashboards={onRefetchDashboards} dashboards={[]} />
+      </MemoryRouter>
+    );
   };
 
   it('renders "Dashboard Hub" heading', () => {
@@ -25,6 +30,13 @@ describe('DashboardHub Header', () => {
   it('"Create dashboard" dropdown button is present', () => {
     mountHeader();
     cy.contains('button', 'Create dashboard').should('be.visible');
+  });
+
+  it('renders breadcrumb navigation', () => {
+    mountHeader();
+    cy.get('.pf-v6-c-breadcrumb').should('be.visible');
+    cy.contains('.pf-v6-c-breadcrumb__item', 'Home').should('be.visible');
+    cy.contains('.pf-v6-c-breadcrumb__item', 'Dashboard Hub').should('be.visible');
   });
 
   describe('Create dashboard dropdown', () => {

--- a/src/Components/DashboardHub/Header/Header.tsx
+++ b/src/Components/DashboardHub/Header/Header.tsx
@@ -1,5 +1,18 @@
-import { Content, Dropdown, DropdownItem, DropdownList, Flex, FlexItem, MenuToggle, MenuToggleElement, PageSection } from '@patternfly/react-core';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Content,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Flex,
+  FlexItem,
+  MenuToggle,
+  MenuToggleElement,
+  PageSection,
+} from '@patternfly/react-core';
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { ImportModal } from '../ImportModal/ImportModal';
 import { CreateModal } from '../../CreateModal/CreateModal';
 import { DuplicateModal } from '../../DuplicateModal/DuplicateModal';
@@ -54,25 +67,35 @@ interface HeaderProps {
 
 const Header: React.FunctionComponent<HeaderProps> = ({ onRefetchDashboards }) => {
   return (
-    <PageSection hasBodyWrapper={false} className="widg-c-page__main-section--header pf-v6-u-p-lg pf-v6-u-p-r-0-on-sm">
-      <Flex className="widg-l-flex--header" direction={{ default: 'column', lg: 'row' }}>
-        <FlexItem alignSelf={{ default: 'alignSelfFlexStart' }}>
-          <Content>
-            <Content component="h1">Dashboard Hub</Content>
-            <Content component="dd" className="pf-v6-u-mt-0">
-              Page description
+    <>
+      <PageSection className="pf-v6-u-pb-0">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/">Home</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>Dashboard Hub</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
+      <PageSection hasBodyWrapper={false} className="widg-c-page__main-section--header pf-v6-u-p-lg pf-v6-u-p-r-0-on-sm">
+        <Flex className="widg-l-flex--header" direction={{ default: 'column', lg: 'row' }}>
+          <FlexItem alignSelf={{ default: 'alignSelfFlexStart' }}>
+            <Content>
+              <Content component="h1">Dashboard Hub</Content>
+              <Content component="dd" className="pf-v6-u-mt-0">
+                Page description
+              </Content>
+              <Content component="a" className="pf-v6-u-mt-0">
+                Learn more about dashboards <ExternalLinkAltIcon />
+              </Content>
             </Content>
-            <Content component="a" className="pf-v6-u-mt-0">
-              Learn more about dashboards <ExternalLinkAltIcon />
-            </Content>
-          </Content>
-        </FlexItem>
+          </FlexItem>
 
-        <FlexItem align={{ default: 'alignLeft', lg: 'alignRight' }}>
-          <CreateDashboardDropdown onRefetchDashboards={onRefetchDashboards} />
-        </FlexItem>
-      </Flex>
-    </PageSection>
+          <FlexItem align={{ default: 'alignLeft', lg: 'alignRight' }}>
+            <CreateDashboardDropdown onRefetchDashboards={onRefetchDashboards} />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+    </>
   );
 };
 

--- a/src/Modules/GenericDashboardPage.tsx
+++ b/src/Modules/GenericDashboardPage.tsx
@@ -1,9 +1,9 @@
-import { PageSection } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, PageSection } from '@patternfly/react-core';
 import React, { useEffect, useRef } from 'react';
 import GridLayout from '../Components/DnDLayout/GridLayout';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { lockedLayoutAtom } from '../state/lockedLayoutAtom';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import useDashboardTemplate from '../hooks/useDashboardTemplate';
 import AddWidgetDrawer from '../Components/WidgetDrawer/WidgetDrawer';
 import GenericHeader from '../Components/GenericHeader/GenericHeader';
@@ -32,6 +32,17 @@ const GenericDashboardPage = () => {
   return (
     <div className="genericDashboardPage">
       <Portal notifications={notifications} removeNotification={removeNotification} />
+      <PageSection className="pf-v6-u-pb-0">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/">Home</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Link to="/dashboard-hub">Dashboard Hub</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>{dashboard?.dashboardName}</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
       <GenericHeader dashboard={dashboard} onRenameDashboard={renameDashboard} />
       <AddWidgetDrawer dismissible={false}>
         <PageSection hasBodyWrapper={false} className="widg-c-page__main-section--grid 6-u-p-md-on-sm">


### PR DESCRIPTION
### Description
     
Added breadcrumb navigation to the Dashboard Hub and individual dashboard pages showing the navigation path. The breadcrumbs use React Router `Link` components to enable client-side navigation without full page reloads, providing a better user experience when navigating between pages.

  **Navigation paths:**
  - Dashboard Hub: `Home > Dashboard Hub`
  - Individual Dashboard: `Home > Dashboard Hub > [Dashboard Name]`

  **Impacted UIs:**
  - Dashboard Hub page (`/dashboard-hub`)
  - Generic dashboard page (`/dashboard-hub/:id`)

  **Steps to reproduce:**
  1. Navigate to Dashboard Hub (`/dashboard-hub`)
  2. Observe breadcrumbs showing: Home > Dashboard Hub
  3. Click on any dashboard to open the generic dashboard page
  4. Observe breadcrumbs showing: Home > Dashboard Hub > [Dashboard Name]
  5. Click breadcrumb links to navigate back without page reload

[RHCLOUD48316](https://redhat.atlassian.net/browse/RHCLOUD-48316)

---

### Screenshots
<img width="1449" height="213" alt="Screenshot 2026-06-09 at 14 15 14" src="https://github.com/user-attachments/assets/a00d5550-972a-47af-acf1-591d56c42904" />
<img width="1435" height="250" alt="Screenshot 2026-06-09 at 14 16 58" src="https://github.com/user-attachments/assets/0a949d94-1371-4444-b976-b3e967282846" />

