### PR TITLE
fix: prevent widget drawer from auto-opening, fix dashboard rename updating UI

### DIFF
--- a/playwright/editing-dashboard.spec.ts
+++ b/playwright/editing-dashboard.spec.ts
@@ -11,7 +11,7 @@ const navigateToDashboardHub = async (page: Page) => {
 
 const navigateToGenericDashboard = async (page: Page, dashboardName: string) => {
   await navigateToDashboardHub(page);
-  await page.getByRole('link', { name: dashboardName }).click();
+  await page.getByRole('link', { name: dashboardName, exact: true }).click();
   await page.getByRole('button', { name: 'Add widgets' }).waitFor({ state: 'visible', timeout: 30000 });
 };
 
@@ -123,6 +123,7 @@ test.describe('Set Dashboard as Homepage from Generic Page', () => {
     await page.getByText(`'${nonDefaultName}' has been set as homepage`).waitFor({ state: 'visible', timeout: 10000 });
 
     await navigateToDashboardHub(page);
+    await page.getByRole('link', { name: nonDefaultName, exact: true }).waitFor({ state: 'visible', timeout: 10000 });
 
     expect(await hasHomeIcon(page, nonDefaultName)).toBe(true);
     expect(await hasHomeIcon(page, defaultName)).toBe(false);

--- a/playwright/widget-layout.spec.ts
+++ b/playwright/widget-layout.spec.ts
@@ -124,4 +124,50 @@ test.describe('Widget Layout - Add Widget from Drawer', () => {
     const resetButton = page.getByRole('button', { name: 'Reset to default' });
     await expect(resetButton).toBeVisible();
   });
+
+  test('should not show the widget drawer by default on page load', async ({ page }) => {
+    const drawerText = page.getByText('Add new and previously removed widgets');
+    await expect(drawerText).not.toBeVisible();
+  });
+});
+
+test.describe('Widget Layout - Empty Dashboard', () => {
+  test('should auto-open the widget drawer when dashboard has no widgets', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await disableCookiePrompt(page);
+
+    await page.route('**/api/widget-layout/v1/*', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [
+              {
+                id: 1,
+                default: true,
+                templateBase: { name: 'landing-landingPage', displayName: 'Landing Page' },
+                templateConfig: { sm: [], md: [], lg: [], xl: [] },
+                dashboardName: 'Test Dashboard',
+                createdAt: '2024-01-01T00:00:00Z',
+                updatedAt: '2024-01-01T00:00:00Z',
+                deletedAt: null,
+                userId: 'test-user',
+              },
+            ],
+          }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const drawerText = page.getByText('Add new and previously removed widgets');
+    await expect(drawerText).toBeVisible({ timeout: 10000 });
+
+    await context.close();
+  });
 });

--- a/playwright/widget-layout.spec.ts
+++ b/playwright/widget-layout.spec.ts
@@ -127,7 +127,7 @@ test.describe('Widget Layout - Add Widget from Drawer', () => {
 
   test('should not show the widget drawer by default on page load', async ({ page }) => {
     const drawerText = page.getByText('Add new and previously removed widgets');
-    await expect(drawerText).not.toBeVisible();
+    await expect(drawerText).not.toBeVisible({ timeout: 60000 });
   });
 });
 
@@ -166,7 +166,7 @@ test.describe('Widget Layout - Empty Dashboard', () => {
     await page.waitForLoadState('domcontentloaded');
 
     const drawerText = page.getByText('Add new and previously removed widgets');
-    await expect(drawerText).toBeVisible({ timeout: 10000 });
+    await expect(drawerText).toBeVisible({ timeout: 60000 });
 
     await context.close();
   });

--- a/playwright/widget-layout.spec.ts
+++ b/playwright/widget-layout.spec.ts
@@ -126,48 +126,48 @@ test.describe('Widget Layout - Add Widget from Drawer', () => {
   });
 
   test('should not show the widget drawer by default on page load', async ({ page }) => {
+    await page.locator('#widget-layout-container .pf-v6-widget-grid-tile__title')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
+
     const drawerText = page.getByText('Add new and previously removed widgets');
-    await expect(drawerText).not.toBeVisible({ timeout: 60000 });
+    await expect(drawerText).not.toBeVisible();
   });
 });
 
 test.describe('Widget Layout - Empty Dashboard', () => {
-  test('should auto-open the widget drawer when dashboard has no widgets', async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
+  test('should auto-open the widget drawer when dashboard has no widgets', async ({ page }) => {
     await disableCookiePrompt(page);
-
-    await page.route('**/api/widget-layout/v1/*', (route) => {
-      if (route.request().method() === 'GET') {
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            data: [
-              {
-                id: 1,
-                default: true,
-                templateBase: { name: 'landing-landingPage', displayName: 'Landing Page' },
-                templateConfig: { sm: [], md: [], lg: [], xl: [] },
-                dashboardName: 'Test Dashboard',
-                createdAt: '2024-01-01T00:00:00Z',
-                updatedAt: '2024-01-01T00:00:00Z',
-                deletedAt: null,
-                userId: 'test-user',
-              },
-            ],
-          }),
-        });
-      }
-      return route.continue();
+    await page.addInitScript(() => {
+      const originalFetch = window.fetch;
+      window.fetch = async (...args) => {
+        const url = typeof args[0] === 'string' ? args[0] : args[0] instanceof Request ? args[0].url : '';
+        if (
+          (url.includes('/api/widget-layout/v1/') && url.includes('dashboardType=')) ||
+          (url.includes('/api/chrome-service/v1/dashboard-templates') && url.includes('dashboard='))
+        ) {
+          return new Response(JSON.stringify({
+            data: [{
+              id: 1,
+              default: true,
+              templateBase: { name: 'landing-landingPage', displayName: 'Landing Page' },
+              templateConfig: { sm: [], md: [], lg: [], xl: [] },
+              dashboardName: 'Test Dashboard',
+              createdAt: '2024-01-01T00:00:00Z',
+              updatedAt: '2024-01-01T00:00:00Z',
+              deletedAt: null,
+              userId: 'test-user',
+            }],
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return originalFetch(...args);
+      };
     });
 
     await page.goto('/');
-    await page.waitForLoadState('domcontentloaded');
+    await page.getByRole('button', { name: 'Add widgets' }).waitFor({ state: 'visible', timeout: 10000 });
 
     const drawerText = page.getByText('Add new and previously removed widgets');
-    await expect(drawerText).toBeVisible({ timeout: 60000 });
-
-    await context.close();
+    await expect(drawerText).toBeVisible({ timeout: 10000 });
   });
 });

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -22,12 +22,14 @@ const sidebarBreakpoints = { xl: 1250, lg: 1100, md: 800, sm: 500 };
 const documentationLink =
   'https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/getting_started_with_the_red_hat_hybrid_cloud_console/index#customizing-main-page_navigating-the-console';
 
-const LayoutEmptyState = () => {
+const LayoutEmptyState = ({ isLoaded = false }: { isLoaded?: boolean }) => {
   const setDrawerExpanded = useSetAtom(drawerExpandedAtom);
 
   useEffect(() => {
-    setDrawerExpanded(true);
-  }, []);
+    if (isLoaded) {
+      setDrawerExpanded(true);
+    }
+  }, [isLoaded]);
 
   return (
     <PageSection hasBodyWrapper={false} className="empty-layout pf-v6-u-p-0">
@@ -110,14 +112,14 @@ const GridLayout = ({ template, saveTemplate, isLoaded, isLayoutLocked = false, 
 
   return (
     <div id="widget-layout-container" style={{ position: 'relative' }} ref={layoutRef}>
-      {activeLayout.length === 0 && isLoaded && <LayoutEmptyState />}
+      {activeLayout.length === 0 && isLoaded && <LayoutEmptyState isLoaded={isLoaded} />}
       {Object.keys(widgetMapping).length > 0 && (
         <PatternFlyGridLayout
           widgetMapping={widgetMapping}
           template={patternFlyTemplate}
           onTemplateChange={handleTemplateChange}
           isLayoutLocked={isLayoutLocked}
-          emptyStateComponent={<LayoutEmptyState />}
+          emptyStateComponent={<LayoutEmptyState isLoaded={isLoaded} />}
           breakpoints={sidebarBreakpoints}
           resizeWidgetConfig={{
             enabled: true,

--- a/src/Components/DnDLayout/GridLayout.tsx
+++ b/src/Components/DnDLayout/GridLayout.tsx
@@ -22,31 +22,21 @@ const sidebarBreakpoints = { xl: 1250, lg: 1100, md: 800, sm: 500 };
 const documentationLink =
   'https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/getting_started_with_the_red_hat_hybrid_cloud_console/index#customizing-main-page_navigating-the-console';
 
-const LayoutEmptyState = ({ isLoaded = false }: { isLoaded?: boolean }) => {
-  const setDrawerExpanded = useSetAtom(drawerExpandedAtom);
-
-  useEffect(() => {
-    if (isLoaded) {
-      setDrawerExpanded(true);
-    }
-  }, [isLoaded]);
-
-  return (
-    <PageSection hasBodyWrapper={false} className="empty-layout pf-v6-u-p-0">
-      <EmptyState headingLevel="h2" icon={PlusCircleIcon} titleText="No dashboard content" variant={EmptyStateVariant.lg} className="pf-v6-u-p-sm">
-        <EmptyStateBody>
-          You don&apos;t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to
-          this dashboard body here.
-        </EmptyStateBody>
-        <EmptyStateActions>
-          <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end" component="a" href={documentationLink}>
-            Learn about your widget dashboard
-          </Button>
-        </EmptyStateActions>
-      </EmptyState>
-    </PageSection>
-  );
-};
+const LayoutEmptyState = () => (
+  <PageSection hasBodyWrapper={false} className="empty-layout pf-v6-u-p-0">
+    <EmptyState headingLevel="h2" icon={PlusCircleIcon} titleText="No dashboard content" variant={EmptyStateVariant.lg} className="pf-v6-u-p-sm">
+      <EmptyStateBody>
+        You don&apos;t have any widgets on your dashboard. To populate your dashboard, drag <GripVerticalIcon /> items from the blue widget bank to
+        this dashboard body here.
+      </EmptyStateBody>
+      <EmptyStateActions>
+        <Button variant="link" icon={<ExternalLinkAltIcon />} iconPosition="end" component="a" href={documentationLink}>
+          Learn about your widget dashboard
+        </Button>
+      </EmptyStateActions>
+    </EmptyState>
+  </PageSection>
+);
 
 const getResizeHandle = (resizeHandleAxis: string, ref: React.Ref<HTMLDivElement>) => (
   <div ref={ref} className={`react-resizable-handle react-resizable-handle-${resizeHandleAxis}`}>
@@ -97,6 +87,10 @@ const GridLayout = ({ template, saveTemplate, isLoaded, isLayoutLocked = false, 
     const activeLayout = newTemplate[layoutVariant] || [];
     setCurrentlyUsedWidgets(activeLayout.map((item) => item.widgetType));
 
+    if (activeLayout.length === 0) {
+      setDrawerExpanded(true);
+    }
+
     await saveTemplate(newTemplate as LocalExtendedTemplateConfig);
   };
 
@@ -110,16 +104,22 @@ const GridLayout = ({ template, saveTemplate, isLoaded, isLayoutLocked = false, 
 
   const activeLayout = patternFlyTemplate[layoutVariant] || [];
 
+  useEffect(() => {
+    if (isLoaded && activeLayout.length === 0) {
+      setDrawerExpanded(true);
+    }
+  }, [isLoaded]);
+
   return (
     <div id="widget-layout-container" style={{ position: 'relative' }} ref={layoutRef}>
-      {activeLayout.length === 0 && isLoaded && <LayoutEmptyState isLoaded={isLoaded} />}
+      {activeLayout.length === 0 && isLoaded && <LayoutEmptyState />}
       {Object.keys(widgetMapping).length > 0 && (
         <PatternFlyGridLayout
           widgetMapping={widgetMapping}
           template={patternFlyTemplate}
           onTemplateChange={handleTemplateChange}
           isLayoutLocked={isLayoutLocked}
-          emptyStateComponent={<LayoutEmptyState isLoaded={isLoaded} />}
+          emptyStateComponent={<LayoutEmptyState />}
           breakpoints={sidebarBreakpoints}
           resizeWidgetConfig={{
             enabled: true,

--- a/src/Modules/GenericDashboardPage.tsx
+++ b/src/Modules/GenericDashboardPage.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumb, BreadcrumbItem, PageSection } from '@patternfly/react-core';
 import React, { useEffect, useRef } from 'react';
 import GridLayout from '../Components/DnDLayout/GridLayout';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { Provider, useAtomValue, useSetAtom } from 'jotai';
 import { lockedLayoutAtom } from '../state/lockedLayoutAtom';
 import { Link, useParams } from 'react-router-dom';
 import useDashboardTemplate from '../hooks/useDashboardTemplate';
@@ -11,8 +11,10 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { resolvedWidgetMappingAtom } from '../state/widgetMappingAtom';
 import { notificationsAtom, useRemoveNotification } from '../state/notificationsAtom';
 import Portal from '@redhat-cloud-services/frontend-components-notifications/Portal';
+import { backendFlagAtom, store } from '../state/store';
+import { useFlag } from '@unleash/proxy-client-react';
 
-const GenericDashboardPage = () => {
+const GenericDashboardPageInner = () => {
   const { id } = useParams<{ id: string }>();
   const isLayoutLocked = useAtomValue(lockedLayoutAtom);
   const { template, saveTemplate, renameDashboard, isLoaded, dashboard } = useDashboardTemplate(Number(id));
@@ -22,6 +24,13 @@ const GenericDashboardPage = () => {
 
   const notifications = useAtomValue(notificationsAtom);
   const removeNotification = useRemoveNotification();
+
+  const setBackendFlag = useSetAtom(backendFlagAtom);
+  const isNewBackend = useFlag('platform.widget-layout.new-backend');
+
+  useEffect(() => {
+    setBackendFlag(isNewBackend);
+  }, [isNewBackend]);
 
   useEffect(() => {
     if (visibilityFunctions) {
@@ -52,5 +61,11 @@ const GenericDashboardPage = () => {
     </div>
   );
 };
+
+const GenericDashboardPage = () => (
+  <Provider store={store}>
+    <GenericDashboardPageInner />
+  </Provider>
+);
 
 export default GenericDashboardPage;

--- a/src/api/dashboard-templates-new.ts
+++ b/src/api/dashboard-templates-new.ts
@@ -264,7 +264,7 @@ export const renameDashboardTemplate = async (templateId: DashboardTemplate['id'
   });
   handleErrors(resp);
   const json = await resp.json();
-  return json.data;
+  return json;
 };
 
 // POST /api/widget-layout/v1/{id}/copy

--- a/src/hooks/useDashboardConfig.ts
+++ b/src/hooks/useDashboardConfig.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import DebouncePromise from 'awesome-debounce-promise';
 import { templateAtom, templateIdAtom } from '../state/templateAtom';
 import { layoutVariantAtom } from '../state/layoutAtom';
@@ -14,6 +14,7 @@ import {
 import useCurrentUser from './useCurrentUser';
 import { useAddNotification } from '../state/notificationsAtom';
 import { useApi } from './useApi';
+import { drawerExpandedAtom } from '../state/drawerExpandedAtom';
 import { useFlag } from '@unleash/proxy-client-react';
 
 const sidebarBreakpoints = { xl: 1250, lg: 1100, md: 800, sm: 500 };
@@ -30,11 +31,19 @@ const useDashboardConfig = (layoutType: LayoutTypes = 'landing-landingPage') => 
   const layoutRef = useRef<HTMLDivElement>(null);
   const api = useApi();
   const debouncedPatchDashboardTemplate = useMemo(() => DebouncePromise(api.patchDashboardTemplate, 1500, { onlyResolvesLast: true }), [api]);
+  const setDrawerExpanded = useSetAtom(drawerExpandedAtom);
 
   useEffect(() => {
-    if (!currentUser || templateId >= 0) {
+    if (!currentUser) {
       return;
     }
+
+    if (templateId >= 0) {
+      setIsLoaded(true);
+      return;
+    }
+
+    setDrawerExpanded(false);
 
     api
       .getDashboardTemplates(mappedLayoutType)

--- a/src/hooks/useDashboardTemplate.ts
+++ b/src/hooks/useDashboardTemplate.ts
@@ -14,6 +14,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { renameDashboardAtom } from '../state/dashboardsAtom';
 import { templateIdAtom } from '../state/templateAtom';
 import { backendFlagAtom } from '../state/store';
+import { drawerExpandedAtom } from '../state/drawerExpandedAtom';
 import { widgetKeyMap } from '../consts';
 
 const remapShortKeys = (config: ExtendedTemplateConfig): ExtendedTemplateConfig => {
@@ -68,8 +69,10 @@ const useDashboardTemplate = (id: number) => {
   const debouncedPatchDashboardTemplate = useMemo(() => DebouncePromise(api.patchDashboardTemplateHub, 1500, { onlyResolvesLast: true }), [api]);
   const renameDashboardInList = useSetAtom(renameDashboardAtom);
   const invalidateStartPage = useSetAtom(templateIdAtom);
+  const setDrawerExpanded = useSetAtom(drawerExpandedAtom);
 
   useEffect(() => {
+    setDrawerExpanded(false);
     const fetchTemplate = async () => {
       setIsLoaded(false);
       setError(null);


### PR DESCRIPTION
## Summary
  
  - Fix widget drawer auto-opening during initial dashboard load — the empty state was triggering the drawer before data finished loading, causing a flash of the drawer on dashboards that have widgets
  - Fix dashboard rename not reflecting in the UI — GenericDashboardPage now uses its own Jotai Provider with the shared store and initializes the backend feature flag, and the rename API return value parsing is corrected
  - Improve e2e test stability — use `exact: true` for link name matching and add explicit waits to avoid flaky assertions


[RHCLOUD47876](https://redhat.atlassian.net/browse/RHCLOUD-47876)

##  Changes

###  Widget drawer auto-open fix (GridLayout.tsx)                                                                             

  - `LayoutEmptyState` now accepts an isLoaded prop and only opens the drawer after the template has finished loading
  - Prevents the drawer from briefly appearing while the dashboard is still fetching data

###  Dashboard rename fix

  - `GenericDashboardPage` wrapped with a Jotai Provider using the shared store so atoms resolve correctly
  - Backend feature flag (platform.widget-layout.new-backend) is now initialized on the generic dashboard page
  - Fixed `renameDashboardTemplate` to return `json` instead of `json.data` to match the actual API response shape

###  E2e tests

  - Added tests verifying the drawer does not auto-open on page load and does auto-open for empty dashboards
  - Used `exact: true` in link selectors to prevent partial name matches causing wrong navigation
  - Added explicit waitFor before assertions that depend on navigation completing

