### PR TITLE
fix: add lookup table to map short widget keys to scoped keys

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,20 @@
 export const dropping_elem_id = '__dropping-elem__';
 
 export const columns = { xl: 4, lg: 3, md: 2, sm: 1 };
+
+export const widgetKeyMap: Record<string, string> = {
+  favoriteServices: 'chrome-./DashboardFavorites',
+  acs: 'landing-./AcsWidget',
+  ansible: 'landing-./AnsibleWidget',
+  exploreCapabilities: 'landing-./ExploreCapabilities',
+  imageBuilder: 'landing-./ImageBuilderWidget',
+  openshift: 'landing-./OpenShiftWidget',
+  openshiftAi: 'landing-./OpenShiftAiWidget',
+  recentlyVisited: 'landing-./RecentlyVisited',
+  rhel: 'landing-./RhelWidget',
+  supportCases: 'landing-./SupportCaseWidget',
+  learningResources: 'learningResources-./BookmarkedLearningResourcesWidget',
+  notificationsEvents: 'notifications-./DashboardWidget',
+  integrations: 'sources-./IntegrationsWidget',
+  subscriptions: 'subscriptionInventory-./SubscriptionsWidget',
+};

--- a/src/hooks/useDashboardTemplate.ts
+++ b/src/hooks/useDashboardTemplate.ts
@@ -10,9 +10,27 @@ import {
   widgetIdSeparator,
 } from '../api/dashboard-templates';
 import { useApi } from './useApi';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { renameDashboardAtom } from '../state/dashboardsAtom';
 import { templateIdAtom } from '../state/templateAtom';
+import { backendFlagAtom } from '../state/store';
+import { widgetKeyMap } from '../consts';
+
+const remapShortKeys = (config: ExtendedTemplateConfig): ExtendedTemplateConfig => {
+  const result: ExtendedTemplateConfig = { sm: [], md: [], lg: [], xl: [] };
+  (Object.keys(config) as Variants[]).forEach((variant) => {
+    result[variant] = config[variant].map((item) => {
+      const [widgetType, uuid] = item.i.split(widgetIdSeparator);
+      const scopedType = widgetKeyMap[widgetType] ?? widgetType;
+      return {
+        ...item,
+        i: `${scopedType}${widgetIdSeparator}${uuid}`,
+        widgetType: scopedType,
+      };
+    });
+  });
+  return result;
+};
 
 const remapWidgetTypes = (extendedTemplate: ExtendedTemplateConfig, widgetMapping: WidgetMapping): ExtendedTemplateConfig => {
   // Build reverse lookup: "landing-./RhelWidget" -> "rhel"
@@ -46,6 +64,7 @@ const useDashboardTemplate = (id: number) => {
   const [error, setError] = useState<Error | null>(null);
   const [dashboard, setDashboard] = useState<DashboardTemplate>();
   const api = useApi();
+  const isNewBackend = useAtomValue(backendFlagAtom);
   const debouncedPatchDashboardTemplate = useMemo(() => DebouncePromise(api.patchDashboardTemplateHub, 1500, { onlyResolvesLast: true }), [api]);
   const renameDashboardInList = useSetAtom(renameDashboardAtom);
   const invalidateStartPage = useSetAtom(templateIdAtom);
@@ -59,8 +78,9 @@ const useDashboardTemplate = (id: number) => {
         const result = await api.getDashboardTemplate(id);
         setDashboard(result);
         const extendedTemplateConfig = mapTemplateConfigToExtendedTemplateConfig(result.templateConfig);
+        const normalized = isNewBackend ? remapShortKeys(extendedTemplateConfig) : extendedTemplateConfig;
         const widgetMap = await api.getWidgetMapping();
-        const remappedTemplate = remapWidgetTypes(extendedTemplateConfig, widgetMap);
+        const remappedTemplate = remapWidgetTypes(normalized, widgetMap);
         setTemplate(remappedTemplate);
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to fetch dashboard template'));
@@ -70,7 +90,7 @@ const useDashboardTemplate = (id: number) => {
     };
 
     fetchTemplate();
-  }, [id]);
+  }, [id, api]);
 
   const renameDashboard = useCallback(
     async (dashboardName: string) => {


### PR DESCRIPTION
## Description

When a user creates a dashboard on the **old** backend, widget IDs are stored with short keys (e.g. rhel#uuid). After switching to the **new** backend, those widgets fail to render because the new backend expects scoped keys (e.g. landing-./RhelWidget#uuid). 

This PR adds a widgetKeyMap lookup table that maps short keys to their scoped equivalents, applied conditionally in useDashboardTemplate only when the new backend flag is on.

This is a **temporary solution**. Once the new backend is fully rolled out and users can no longer switch back to the old one, the widgetKeyMap and remapShortKeys can be removed.

  - Adds widgetKeyMap in src/consts.ts mapping short widget keys → scoped keys
  - Adds remapShortKeys() in useDashboardTemplate hook, called only when isNewBackend is true