### PR TITLE
fix: remove dashboardHub module from frontend.yaml

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -28,11 +28,6 @@ objects:
             module: ./RootApp
             routes:
             - pathname: /staging/widget-layout
-          - id: dashboardHub
-            module: ./DashboardHub
-            routes:
-            - pathname: /dashboard-hub
-
 parameters:
   - name: ENV_NAME
     required: true


### PR DESCRIPTION
### Description
Remove `dashboardHub` as a separate federated module from `frontend.yaml`. The Dashboard Hub page is rendered internally, so a dedicated module entry is unnecessary.