### PR TITLE
fix(RHCLOUD-49089): improve dark mode contrast for widget controls

### DIFF
--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -249,7 +249,7 @@ const Controls = () => {
             onClick={() => {
               toggleOpen((prev) => !prev);
             }}
-            variant="secondary"
+            variant="primary"
             icon={<PlusCircleIcon />}
             ouiaId="add-widget-button"
           >

--- a/src/Components/WidgetDrawer/WidgetDrawer.tsx
+++ b/src/Components/WidgetDrawer/WidgetDrawer.tsx
@@ -34,7 +34,7 @@ const WidgetWrapper = ({ widgetType, config }: React.PropsWithChildren<{ widgetT
   const headerActions = (
     <Tooltip content={<p>Move widget</p>}>
       <Icon className="pf-v6-u-pt-md widg-c-drawer__drag-handle">
-        <GripVerticalIcon style={{ fill: 'var(--pf-t--global--icon--color--subtle)' }} />
+        <GripVerticalIcon style={{ fill: 'var(--pf-t--global--icon--color--regular)' }} />
       </Icon>
     </Tooltip>
   );


### PR DESCRIPTION
## Summary
- Change "Add widgets" button from `secondary` to `primary` variant for better text contrast in dark/glass theme
- Use `--pf-t--global--icon--color--regular` token instead of `--subtle` for the drag handle icon to increase visibility
- Both changes use PatternFly design tokens and variants, no custom CSS overrides

## Test plan
- [ ] Enable dark/glass theme in HCC console
- [ ] Verify "Add widgets" button text is readable against the blue background
- [ ] Verify the drag handle (grip) icon on widget cards is clearly visible
- [ ] Verify light mode appearance is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)