### PR TITLE
fix: remove unused description column from dashboard hub table

### DIFF
--- a/cypress/component/DashboardTable.cy.tsx
+++ b/cypress/component/DashboardTable.cy.tsx
@@ -76,7 +76,6 @@ describe('DashboardTable', () => {
     cy.mount(<MemoryRouter><DashboardTable dashboards={mockDashboards}  onRefetchDashboards={cy.stub()}/></MemoryRouter>);
 
     cy.get('th').contains('Name').should('be.visible');
-    cy.get('th').contains('Description').should('be.visible');
     cy.get('th').contains('Last Modified').should('be.visible');
   });
 
@@ -88,19 +87,16 @@ describe('DashboardTable', () => {
     // Default sort is ascending by name, so order should be: Alpha, Bravo, Charlie
     cy.get('tbody tr').eq(0).within(() => {
       cy.get('td[data-label="Name"]').should('contain.text', 'Alpha Dashboard');
-      cy.get('td[data-label="Description"]').should('contain.text', 'Base Template Beta');
       cy.get('td[data-label="Last Modified"]').should('not.be.empty');
     });
 
     cy.get('tbody tr').eq(1).within(() => {
       cy.get('td[data-label="Name"]').should('contain.text', 'Bravo Dashboard');
-      cy.get('td[data-label="Description"]').should('contain.text', 'Base Template Gamma');
       cy.get('td[data-label="Last Modified"]').should('not.be.empty');
     });
 
     cy.get('tbody tr').eq(2).within(() => {
       cy.get('td[data-label="Name"]').should('contain.text', 'Charlie Dashboard');
-      cy.get('td[data-label="Description"]').should('contain.text', 'Base Template Alpha');
       cy.get('td[data-label="Last Modified"]').should('not.be.empty');
     });
   });
@@ -132,7 +128,6 @@ describe('DashboardTable', () => {
 
     // Headers should still render
     cy.get('th').contains('Name').should('be.visible');
-    cy.get('th').contains('Description').should('be.visible');
     cy.get('th').contains('Last Modified').should('be.visible');
 
     // No body rows

--- a/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
+++ b/src/Components/DashboardHub/DashboardTable/DashboardTable.tsx
@@ -18,7 +18,6 @@ import { useSetAtom } from 'jotai';
 interface Dashboard {
   id: number;
   name: string;
-  description: string; // TODO
   lastModified: string;
   isDefault: boolean;
 }
@@ -45,14 +44,12 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
   const tableData: Dashboard[] = dashboards.map((dashboard) => ({
     id: dashboard.id,
     name: dashboard.dashboardName,
-    description: dashboard.templateBase.name, // TODO: Update when description field is available
     lastModified: dashboard.updatedAt,
     isDefault: dashboard.default,
   }));
 
   const columnNames = {
     name: 'Name',
-    description: 'Description',
     lastModified: 'Last Modified',
     actions: '',
   };
@@ -188,7 +185,6 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
           <Tr>
             <Th screenReaderText="Homepage" modifier="fitContent" />
             <Th sort={getSortParams()}>{columnNames.name}</Th>
-            <Th>{columnNames.description}</Th>
             <Th>{columnNames.lastModified}</Th>
             <Th screenReaderText="Actions" />
           </Tr>
@@ -200,7 +196,6 @@ export const DashboardTable: React.FunctionComponent<DashboardTableProps> = ({ d
               <Td dataLabel={columnNames.name}>
                 <Link to={`/dashboard-hub/${dashboard.id}`}>{dashboard.name}</Link>
               </Td>
-              <Td dataLabel={columnNames.description}>{dashboard.description}</Td>
               <Td dataLabel={columnNames.lastModified}>
                 <DateFormat date={dashboard.lastModified} />
               </Td>


### PR DESCRIPTION
### Description
Remove the unused "Description" column from the Dashboard Hub table. The column was displaying `templateBase.name` as a placeholder — the backend never implemented a dedicated description field.

  Changes:
  - Removed description from the Dashboard interface, data mapping, and column definitions in DashboardTable.tsx
  - Removed the <Th> header and <Td> cell rendering the description column
  - Updated Cypress component tests to remove description assertions

<img width="1400" height="346" alt="Screenshot 2026-07-21 at 13 25 45" src="https://github.com/user-attachments/assets/606f8b08-0064-4876-9b4e-ff343b52af8d" />

[RHCLOUD-49467](https://redhat.atlassian.net/browse/RHCLOUD-49467)

[RHCLOUD-49467]: https://redhat.atlassian.net/browse/RHCLOUD-49467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ