### PR TITLE
fix: hide link on dashboard hub under featur flag, fix tests

### DIFF
--- a/cypress/component/Header.cy.tsx
+++ b/cypress/component/Header.cy.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
+import FlagProvider from '@unleash/proxy-client-react';
+import { UnleashClient } from 'unleash-proxy-client';
 import { MemoryRouter } from 'react-router-dom';
 import Header from '../../src/Components/DashboardHub/Header/Header';
 
+const createMockClient = (flagEnabled: boolean) => {
+  const client = new UnleashClient({
+    url: 'http://api/frontend',
+    clientKey: 'test',
+    appName: 'test',
+  });
+  client.isEnabled = () => flagEnabled;
+  return client;
+};
+
 describe('DashboardHub Header', () => {
-  const mountHeader = () => {
+  const mountHeader = (flagEnabled = false) => {
     const onRefetchDashboards = cy.stub().as('onRefetchDashboards');
     cy.mount(
       <MemoryRouter>
-        <Header onRefetchDashboards={onRefetchDashboards} dashboards={[]} />
+        <FlagProvider unleashClient={createMockClient(flagEnabled)} startClient={false}>
+          <Header onRefetchDashboards={onRefetchDashboards} dashboards={[]} />
+        </FlagProvider>
       </MemoryRouter>
     );
   };
@@ -22,9 +36,14 @@ describe('DashboardHub Header', () => {
     cy.contains('Page description').should('be.visible');
   });
 
-  it('shows "Learn more about dashboards" link', () => {
-    mountHeader();
+  it('shows "Learn more about dashboards" link when feature flag is enabled', () => {
+    mountHeader(true);
     cy.contains('a', 'Learn more about dashboards').should('be.visible');
+  });
+
+  it('hides "Learn more about dashboards" link when feature flag is disabled', () => {
+    mountHeader();
+    cy.contains('a', 'Learn more about dashboards').should('not.exist');
   });
 
   it('"Create dashboard" dropdown button is present', () => {

--- a/src/Components/DashboardHub/Header/Header.tsx
+++ b/src/Components/DashboardHub/Header/Header.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useFlag } from '@unleash/proxy-client-react';
 import { ImportModal } from '../ImportModal/ImportModal';
 import { CreateModal } from '../../CreateModal/CreateModal';
 import { DuplicateModal } from '../../DuplicateModal/DuplicateModal';
@@ -66,6 +67,7 @@ interface HeaderProps {
 }
 
 const Header: React.FunctionComponent<HeaderProps> = ({ onRefetchDashboards }) => {
+  const isLearnMoreLink = useFlag('platform.widget-layout.learn-more-link');
   return (
     <>
       <PageSection className="pf-v6-u-pb-0">
@@ -84,9 +86,11 @@ const Header: React.FunctionComponent<HeaderProps> = ({ onRefetchDashboards }) =
               <Content component="dd" className="pf-v6-u-mt-0">
                 Page description
               </Content>
-              <Content component="a" className="pf-v6-u-mt-0">
-                Learn more about dashboards <ExternalLinkAltIcon />
-              </Content>
+              {isLearnMoreLink && (
+                <Content component="a" className="pf-v6-u-mt-0">
+                  Learn more about dashboards <ExternalLinkAltIcon />
+                </Content>
+              )}
             </Content>
           </FlexItem>
 


### PR DESCRIPTION
### Description
Hide the "Learn more about dashboards" link in the Dashboard Hub header behind the `platform.widget-layout.learn-more-link` feature flag. The link will only render when the flag is enabled.

Updated the Cypress component tests for the `Header.tsx` to wrap the component in FlagProvider with a mock Unleash client, and split the "Learn more" test into two cases: one verifying the link appears when the flag is on, and one verifying it's hidden when the flag is off.

Related to [RHCLOUD-49469](https://redhat.atlassian.net/browse/RHCLOUD-49469)

[RHCLOUD-49469]: https://redhat.atlassian.net/browse/RHCLOUD-49469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ