### PR TITLE
Fix close button alignment in add widget section

### DIFF
--- a/src/Components/WidgetDrawer/WidgetDrawer.tsx
+++ b/src/Components/WidgetDrawer/WidgetDrawer.tsx
@@ -19,7 +19,6 @@ import { drawerExpandedAtom } from '../../state/drawerExpandedAtom';
 import { CloseIcon, GripVerticalIcon } from '@patternfly/react-icons';
 import { currentDropInItemAtom } from '../../state/currentDropInItemAtom';
 import { widgetMappingAtom } from '../../state/widgetMappingAtom';
-import { getWidget } from '../Widgets/widgetDefaults';
 import HeaderIcon from '../Icons/HeaderIcon';
 import { WidgetConfiguration } from '../../api/dashboard-templates';
 import { currentlyUsedWidgetsAtom } from '../../state/currentlyUsedWidgetsAtom';
@@ -87,18 +86,17 @@ const AddWidgetDrawer = ({ children }: AddWidgetDrawerProps) => {
   const filteredWidgetMapping = Object.entries(widgetMapping).filter(([type]) => !currentlyUsedWidgets.includes(type));
 
   const panelContent = (
-    <PageSection hasBodyWrapper={false} className="widg-c-page__main-section--drawer pf-v6-u-p-md pf-v6-u-p-lg-on-sm">
-      <Split className="widg-l-split--add-widget">
+    <PageSection hasBodyWrapper={false} className="widg-c-page__main-section--drawer">
+      <Split className="widg-l-split--add-widget pf-v6-u-align-items-center">
         <SplitItem isFilled>
-          <Title headingLevel="h2" size="md" className="pf-v6-u-pb-sm">
+          <Title headingLevel="h2" size="md">
             Add new and previously removed widgets by clicking the <GripVerticalIcon /> icon, then drag and drop to a new location. Drag the corners
             of the cards to resize widgets.
           </Title>
         </SplitItem>
-        <SplitItem>
+        <SplitItem className="pf-v6-u-align-self-flex-start">
           <Button
             variant="plain"
-            className="pf-v6-u-pt-0 pf-v6-u-pr-0"
             onClick={() => {
               toggleOpen((prev) => !prev);
             }}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Fix close button alignment in add widget section

[RHCLOUD-49085](https://redhat.atlassian.net/browse/RHCLOUD-49085)
Center close button in Add Widget section - which appears off in High Contrast theme.

**Note:
Centering the close button appears to make the button slightly shifted down in the other themes where this border isn't as visible. Confirmed with UX.**

#### Before
<img width="838" height="144" alt="image" src="https://github.com/user-attachments/assets/c1fa4d40-4e59-486a-a017-31b46b587eb6" />

##### After
<img width="838" height="144" alt="image" src="https://github.com/user-attachments/assets/7348916c-98c4-41c9-802d-7fffdec1e596" />


---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="838" height="144" alt="image" src="https://github.com/user-attachments/assets/f8a34b73-0d59-41b0-b086-37dc1bed1302" />

#### After:
<img width="838" height="144" alt="image" src="https://github.com/user-attachments/assets/7d1157ce-8f7b-4168-a15d-594060170668" />

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-49085]: https://redhat.atlassian.net/browse/RHCLOUD-49085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ